### PR TITLE
Introduce structMap and Value.ReflectTo

### DIFF
--- a/.github/workflows/dgo_build.yml
+++ b/.github/workflows/dgo_build.yml
@@ -19,6 +19,11 @@ jobs:
     - name: Set up GolangCI-Lint
       run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- v1.17.1
 
+    - name: Lint
+      env:
+        GO111MODULE: on
+      run: ./bin/golangci-lint -E gocritic -E misspell -E gocyclo -E golint -E gosec run ./...
+
     - name: Test
       env:
         GO111MODULE: on
@@ -28,8 +33,3 @@ jobs:
       run: |
         COV=$(go tool cover -func=coverage.tmp | grep -e '^total:\s*(statements)' | awk '{ print $3 }')
         test $COV = '100.0%' || (echo "Expected 100% test coverage, got $COV" && exit 1)
-
-    - name: Lint
-      env:
-        GO111MODULE: on
-      run: ./bin/golangci-lint -E gocritic -E misspell -E gocyclo -E golint -E gosec run ./...

--- a/dgo/array.go
+++ b/dgo/array.go
@@ -54,6 +54,7 @@ type (
 		Iterable
 		Freezable
 		Comparable
+		ReflectedValue
 		util.Indentable
 		json.Marshaler
 		json.Unmarshaler
@@ -199,6 +200,7 @@ type (
 	// ArrayType is implemented by types representing implementations of the Array value
 	ArrayType interface {
 		SizedType
+
 		// ElementType returns the type of the elements for instances of this type
 		ElementType() Type
 	}

--- a/dgo/binary.go
+++ b/dgo/binary.go
@@ -13,6 +13,7 @@ type (
 		Value
 		Comparable
 		Freezable
+		ReflectedValue
 
 		// Copy returns a copy of the Binary. The copy is frozen or mutable depending on
 		// the given argument. A request to create a frozen copy of an already frozen Binary

--- a/dgo/map.go
+++ b/dgo/map.go
@@ -40,6 +40,7 @@ type (
 	Map interface {
 		Value
 		Freezable
+		ReflectedValue
 		util.Indentable
 		json.Marshaler
 		json.Unmarshaler

--- a/dgo/primitive.go
+++ b/dgo/primitive.go
@@ -39,6 +39,15 @@ type (
 		HashCode() int
 	}
 
+	// ReflectedValue is implemented by all values that can be assigned to a reflected value in
+	// a go native form.
+	ReflectedValue interface {
+		// ReflectTo assigns the go native form of this value to the given reflect.Value. The given
+		// reflect.Value must be of a type that the native form of this value is assignable to or a pointer
+		// to such a type.
+		ReflectTo(value reflect.Value)
+	}
+
 	// A Type describes an immutable Value. The Type is in itself also a Value
 	Type interface {
 		Value
@@ -52,6 +61,9 @@ type (
 		// TypeIdentifier returns a unique identifier for this type. The TypeIdentifier is intended to be used by
 		// decorators providing string representation of the type
 		TypeIdentifier() TypeIdentifier
+
+		// ReflectType returns the reflect.Type that corresponds to the receiver
+		ReflectType() reflect.Type
 	}
 
 	// Number is implemented by Float and Integer implementations
@@ -68,6 +80,7 @@ type (
 		Value
 		Number
 		Comparable
+		ReflectedValue
 
 		// GoInt returns the Go native representation of this value
 		GoInt() int64
@@ -95,6 +108,7 @@ type (
 		Value
 		Number
 		Comparable
+		ReflectedValue
 
 		// GoFloat returns the Go native representation of this value
 		GoFloat() float64
@@ -121,6 +135,7 @@ type (
 	String interface {
 		Value
 		Comparable
+		ReflectedValue
 
 		// GoString returns the Go native representation of this value
 		GoString() string
@@ -129,6 +144,7 @@ type (
 	// Regexp value is a string that implements the Value interface
 	Regexp interface {
 		Value
+		ReflectedValue
 
 		// GoRegexp returns the Go native representation of this value
 		GoRegexp() *regexp.Regexp
@@ -143,6 +159,7 @@ type (
 	Boolean interface {
 		Value
 		Comparable
+		ReflectedValue
 
 		// GoBool returns the Go native representation of this value
 		GoBool() bool
@@ -169,6 +186,7 @@ type (
 	Native interface {
 		Value
 		Freezable
+		ReflectedValue
 
 		// GoValue returns the Go native representation of this value
 		GoValue() interface{}

--- a/internal/any.go
+++ b/internal/any.go
@@ -1,12 +1,18 @@
 package internal
 
-import "github.com/lyraproj/dgo/dgo"
+import (
+	"reflect"
+
+	"github.com/lyraproj/dgo/dgo"
+)
 
 // anyType represents all possible values
 type anyType int
 
 // DefaultAnyType is the unconstrained Any type
 const DefaultAnyType = anyType(0)
+
+var reflectAnyType = reflect.TypeOf((*interface{})(nil)).Elem()
 
 func (t anyType) Assignable(other dgo.Type) bool {
 	return true
@@ -22,6 +28,11 @@ func (t anyType) HashCode() int {
 
 func (t anyType) Instance(value interface{}) bool {
 	return true
+}
+
+// ReflectType returns the reflect.Type for the given dgo.Type
+func (t anyType) ReflectType() reflect.Type {
+	return reflectAnyType
 }
 
 func (t anyType) String() string {

--- a/internal/binary_test.go
+++ b/internal/binary_test.go
@@ -20,7 +20,7 @@ import (
 func TestBinaryType(t *testing.T) {
 	bs := []byte{1, 2, 3}
 	v := vf.Binary(bs, false)
-	tp := v.Type()
+	tp := v.Type().(dgo.BinaryType)
 	require.Assignable(t, typ.Binary, tp)
 	require.NotAssignable(t, tp, typ.Binary)
 	require.NotAssignable(t, tp, typ.String)
@@ -56,6 +56,8 @@ func TestBinaryType(t *testing.T) {
 	require.Panic(t, func() { newtype.Binary(1, `blue`) }, `illegal argument 2`)
 	require.Panic(t, func() { newtype.Binary(1, 2, 3) }, `illegal number of arguments`)
 	require.Equal(t, `binary[3,3]`, tp.String())
+
+	require.Equal(t, reflect.TypeOf([]byte{}), tp.ReflectType())
 }
 
 func TestBinary(t *testing.T) {
@@ -193,4 +195,25 @@ func TestBinary_FrozenEqual(t *testing.T) {
 	require.NotSame(t, a, b)
 	require.NotSame(t, b, b.Copy(true))
 	require.NotSame(t, b, b.Copy(false))
+}
+
+func TestBinary_ReflectTo(t *testing.T) {
+	var s []byte
+	b := vf.Binary([]byte{1, 2}, true)
+	b.ReflectTo(reflect.ValueOf(&s).Elem())
+	require.Equal(t, b, s)
+
+	s = nil
+	sp := &s
+	b.ReflectTo(reflect.ValueOf(&sp).Elem())
+	s = *sp
+	require.Equal(t, b, s)
+
+	var mi interface{}
+	mip := &mi
+	b.ReflectTo(reflect.ValueOf(mip).Elem())
+
+	bc, ok := mi.([]byte)
+	require.True(t, ok)
+	require.Equal(t, b, bc)
 }

--- a/internal/boolean.go
+++ b/internal/boolean.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"reflect"
+
 	"github.com/lyraproj/dgo/dgo"
 	"gopkg.in/yaml.v3"
 )
@@ -54,6 +56,12 @@ func (t booleanType) Instance(v interface{}) bool {
 
 func (t booleanType) IsInstance(v bool) bool {
 	return t < 0 || (t == 1) == v
+}
+
+var reflectBooleanType = reflect.TypeOf(true)
+
+func (t booleanType) ReflectType() reflect.Type {
+	return reflectBooleanType
 }
 
 func (t booleanType) String() string {
@@ -118,6 +126,18 @@ func (v boolean) HashCode() int {
 
 func (v boolean) MarshalYAML() (interface{}, error) {
 	return &yaml.Node{Kind: yaml.ScalarNode, Tag: `!!bool`, Value: v.String()}, nil
+}
+
+func (v boolean) ReflectTo(value reflect.Value) {
+	b := bool(v)
+	switch value.Kind() {
+	case reflect.Interface:
+		value.Set(reflect.ValueOf(b))
+	case reflect.Ptr:
+		value.Set(reflect.ValueOf(&b))
+	default:
+		value.SetBool(b)
+	}
 }
 
 func (v boolean) String() string {

--- a/internal/boolean_test.go
+++ b/internal/boolean_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/lyraproj/dgo/dgo"
@@ -58,6 +59,8 @@ func TestBooleanType(t *testing.T) {
 	require.NotEqual(t, typ.Boolean.HashCode(), typ.False.HashCode())
 	require.NotEqual(t, typ.True.HashCode(), typ.False.HashCode())
 	require.Equal(t, `bool`, typ.Boolean.String())
+
+	require.Equal(t, reflect.TypeOf(false), typ.True.ReflectType())
 }
 
 func TestBoolean(t *testing.T) {
@@ -108,6 +111,23 @@ func TestBoolean_CompareTo(t *testing.T) {
 
 	_, ok = vf.True.CompareTo(vf.Integer(1))
 	require.False(t, ok)
+}
+
+func TestBoolean_ReflectTo(t *testing.T) {
+	var b bool
+	vf.True.ReflectTo(reflect.ValueOf(&b).Elem())
+	require.True(t, b)
+
+	var bp *bool
+	vf.True.ReflectTo(reflect.ValueOf(&bp).Elem())
+	require.True(t, *bp)
+
+	var mi interface{}
+	mip := &mi
+	vf.True.ReflectTo(reflect.ValueOf(mip).Elem())
+	bc, ok := mi.(bool)
+	require.True(t, ok)
+	require.True(t, bc)
 }
 
 func TestBoolean_String(t *testing.T) {

--- a/internal/error.go
+++ b/internal/error.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"reflect"
+
 	"github.com/lyraproj/dgo/dgo"
 )
 
@@ -14,6 +16,8 @@ type (
 
 // DefaultErrorType is the unconstrained Error type
 const DefaultErrorType = errType(0)
+
+var reflectErrorType = reflect.TypeOf((*error)(nil)).Elem()
 
 func (t errType) Type() dgo.Type {
 	return &metaType{t}
@@ -37,6 +41,10 @@ func (t errType) Assignable(other dgo.Type) bool {
 func (t errType) Instance(value interface{}) bool {
 	_, ok := value.(error)
 	return ok
+}
+
+func (t errType) ReflectType() reflect.Type {
+	return reflectErrorType
 }
 
 func (t errType) String() string {
@@ -63,6 +71,14 @@ func (e *errw) HashCode() int {
 
 func (e *errw) Error() string {
 	return e.error.Error()
+}
+
+func (e *errw) ReflectTo(value reflect.Value) {
+	if value.Kind() == reflect.Ptr {
+		value.Set(reflect.ValueOf(&e.error))
+	} else {
+		value.Set(reflect.ValueOf(e.error))
+	}
 }
 
 func (e *errw) String() string {

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -2,6 +2,7 @@ package internal_test
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	require "github.com/lyraproj/dgo/dgo_test"
@@ -25,6 +26,8 @@ func TestErrorType(t *testing.T) {
 	require.NotEqual(t, 0, tp.HashCode())
 
 	require.Equal(t, `error`, tp.String())
+
+	require.True(t, reflect.TypeOf(er).AssignableTo(tp.ReflectType()))
 }
 
 type testUnwrapError struct {
@@ -71,4 +74,25 @@ func TestError(t *testing.T) {
 	u, ok = uv.(uvt)
 	require.True(t, ok)
 	require.Equal(t, u.Unwrap(), ev)
+}
+
+func TestError_ReflectTo(t *testing.T) {
+	var err error
+	v := vf.Value(errors.New(`some error`))
+	vf.ReflectTo(v, reflect.ValueOf(&err).Elem())
+	require.NotNil(t, err)
+	require.Equal(t, `some error`, err.Error())
+
+	var bp *error
+	vf.ReflectTo(v, reflect.ValueOf(&bp).Elem())
+	require.NotNil(t, bp)
+	require.NotNil(t, *bp)
+	require.Equal(t, `some error`, (*bp).Error())
+
+	var mi interface{}
+	mip := &mi
+	vf.ReflectTo(v, reflect.ValueOf(mip).Elem())
+	ec, ok := mi.(error)
+	require.True(t, ok)
+	require.Same(t, err, ec)
 }

--- a/internal/float_test.go
+++ b/internal/float_test.go
@@ -2,6 +2,7 @@ package internal_test
 
 import (
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/lyraproj/dgo/dgo"
@@ -29,6 +30,8 @@ func TestFloat(t *testing.T) {
 	require.NotEqual(t, 0, typ.Float.HashCode())
 
 	require.Equal(t, `float`, typ.Float.String())
+
+	require.Equal(t, reflect.ValueOf(3.14).Type(), typ.Float.ReflectType())
 }
 
 func TestFloatExact(t *testing.T) {
@@ -54,6 +57,8 @@ func TestFloatExact(t *testing.T) {
 	require.Equal(t, `3.1415927`, tp.String())
 
 	require.Instance(t, tp.Type(), tp)
+
+	require.Same(t, tp.ReflectType(), typ.Float.ReflectType())
 }
 
 func TestFloatRange(t *testing.T) {
@@ -91,6 +96,8 @@ func TestFloatRange(t *testing.T) {
 	require.Equal(t, `3.1...5.8`, tp.String())
 
 	require.Panic(t, func() { newtype.FloatRange(3.1, 3.1, false) }, `cannot have equal min and max`)
+
+	require.Same(t, tp.ReflectType(), typ.Float.ReflectType())
 }
 
 func TestNumber(t *testing.T) {
@@ -134,6 +141,34 @@ func TestFloat_CompareTo(t *testing.T) {
 
 	_, ok = vf.Float(3.14).CompareTo(vf.True)
 	require.False(t, ok)
+}
+
+func TestFloat_ReflectTo(t *testing.T) {
+	var f float64
+	fv := vf.Float(0.5403)
+	fv.ReflectTo(reflect.ValueOf(&f).Elem())
+	require.Equal(t, f, fv)
+
+	var fp *float64
+	fv.ReflectTo(reflect.ValueOf(&fp).Elem())
+	require.Equal(t, f, *fp)
+
+	var mi interface{}
+	mip := &mi
+	fv.ReflectTo(reflect.ValueOf(mip).Elem())
+	fc, ok := mi.(float64)
+	require.True(t, ok)
+	require.Equal(t, fv, fc)
+
+	fx := float32(0.5403)
+	fv = vf.Float(float64(fx))
+	var f32 float32
+	fv.ReflectTo(reflect.ValueOf(&f32).Elem())
+	require.Equal(t, f32, fv)
+
+	var fp32 *float32
+	fv.ReflectTo(reflect.ValueOf(&fp32).Elem())
+	require.Equal(t, fx, *fp32)
 }
 
 func TestFloat_String(t *testing.T) {

--- a/internal/integer_test.go
+++ b/internal/integer_test.go
@@ -2,6 +2,7 @@ package internal_test
 
 import (
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/lyraproj/dgo/dgo"
@@ -26,6 +27,8 @@ func TestInteger(t *testing.T) {
 	require.True(t, typ.Integer.Inclusive())
 
 	require.Equal(t, `int`, typ.Integer.String())
+
+	require.True(t, reflect.ValueOf(int64(3)).Type().AssignableTo(typ.Integer.ReflectType()))
 }
 
 func TestIntegerExact(t *testing.T) {
@@ -49,6 +52,8 @@ func TestIntegerExact(t *testing.T) {
 	require.Equal(t, `3`, tp.String())
 
 	require.Instance(t, tp.Type(), tp)
+
+	require.Same(t, tp.ReflectType(), typ.Integer.ReflectType())
 }
 
 func TestIntegerRange(t *testing.T) {
@@ -87,6 +92,8 @@ func TestIntegerRange(t *testing.T) {
 	require.Assignable(t, newtype.IntegerRange(3, 4, true), tp)
 
 	require.Panic(t, func() { newtype.IntegerRange(4, 4, false) }, `cannot have equal min and max`)
+
+	require.Same(t, tp.ReflectType(), typ.Integer.ReflectType())
 }
 
 func TestInteger_CompareTo(t *testing.T) {
@@ -124,6 +131,114 @@ func TestInteger_CompareTo(t *testing.T) {
 
 	_, ok = vf.Integer(3).CompareTo(vf.True)
 	require.False(t, ok)
+}
+
+func TestInteger_ReflectTo(t *testing.T) {
+	var i int
+	iv := vf.Integer(42)
+	iv.ReflectTo(reflect.ValueOf(&i).Elem())
+	require.Equal(t, i, iv)
+
+	var ip *int
+	iv.ReflectTo(reflect.ValueOf(&ip).Elem())
+	require.Equal(t, i, *ip)
+
+	var mi interface{}
+	mip := &mi
+	iv.ReflectTo(reflect.ValueOf(mip).Elem())
+	ic, ok := mi.(int64)
+	require.True(t, ok)
+	require.Equal(t, iv, ic)
+
+	ix8 := int8(42)
+	iv = vf.Integer(int64(ix8))
+	var i8 int8
+	iv.ReflectTo(reflect.ValueOf(&i8).Elem())
+	require.Equal(t, i8, iv)
+
+	var ip8 *int8
+	iv.ReflectTo(reflect.ValueOf(&ip8).Elem())
+	require.Equal(t, ix8, *ip8)
+
+	ix16 := int16(42)
+	iv = vf.Integer(int64(ix16))
+	var i16 int16
+	iv.ReflectTo(reflect.ValueOf(&i16).Elem())
+	require.Equal(t, i16, iv)
+
+	var ip16 *int16
+	iv.ReflectTo(reflect.ValueOf(&ip16).Elem())
+	require.Equal(t, ix16, *ip16)
+
+	ix32 := int32(42)
+	iv = vf.Integer(int64(ix32))
+	var i32 int32
+	iv.ReflectTo(reflect.ValueOf(&i32).Elem())
+	require.Equal(t, i32, iv)
+
+	var ip32 *int32
+	iv.ReflectTo(reflect.ValueOf(&ip32).Elem())
+	require.Equal(t, ix32, *ip32)
+
+	ix64 := int64(42)
+	iv = vf.Integer(ix64)
+	var i64 int64
+	iv.ReflectTo(reflect.ValueOf(&i64).Elem())
+	require.Equal(t, i64, iv)
+
+	var ip64 *int64
+	iv.ReflectTo(reflect.ValueOf(&ip64).Elem())
+	require.Equal(t, ix64, *ip64)
+
+	uix := uint(42)
+	iv = vf.Integer(int64(uix))
+	var ui uint
+	iv.ReflectTo(reflect.ValueOf(&ui).Elem())
+	require.Equal(t, ui, iv)
+
+	var uip *uint
+	iv.ReflectTo(reflect.ValueOf(&uip).Elem())
+	require.Equal(t, uix, *uip)
+
+	uix8 := uint8(42)
+	iv = vf.Integer(int64(uix8))
+	var ui8 uint8
+	iv.ReflectTo(reflect.ValueOf(&ui8).Elem())
+	require.Equal(t, ui8, iv)
+
+	var uip8 *uint8
+	iv.ReflectTo(reflect.ValueOf(&uip8).Elem())
+	require.Equal(t, uix8, *uip8)
+
+	uix16 := uint16(42)
+	iv = vf.Integer(int64(uix16))
+	var ui16 uint16
+	iv.ReflectTo(reflect.ValueOf(&ui16).Elem())
+	require.Equal(t, ui16, iv)
+
+	var uip16 *uint16
+	iv.ReflectTo(reflect.ValueOf(&uip16).Elem())
+	require.Equal(t, uix16, *uip16)
+
+	uix32 := uint32(42)
+	iv = vf.Integer(int64(uix32))
+	var ui32 uint32
+	iv.ReflectTo(reflect.ValueOf(&ui32).Elem())
+	require.Equal(t, ui32, iv)
+
+	var uip32 *uint32
+	iv.ReflectTo(reflect.ValueOf(&uip32).Elem())
+	require.Equal(t, uix32, *uip32)
+
+	uix64 := uint64(42)
+	iv = vf.Integer(int64(uix64))
+	var ui64 uint64
+	iv.ReflectTo(reflect.ValueOf(&ui64).Elem())
+	require.Equal(t, ui64, iv)
+
+	var uip64 *uint64
+	iv.ReflectTo(reflect.ValueOf(&uip64).Elem())
+	require.Equal(t, uix64, *uip64)
 }
 
 func TestInteger_String(t *testing.T) {

--- a/internal/meta.go
+++ b/internal/meta.go
@@ -1,8 +1,12 @@
 package internal
 
 import (
+	"reflect"
+
 	"github.com/lyraproj/dgo/dgo"
 )
+
+var reflectTypeType = reflect.TypeOf((*dgo.Type)(nil)).Elem()
 
 // metaType is the Type returned by a Type
 type metaType struct {
@@ -59,6 +63,10 @@ func (t *metaType) Operator() dgo.TypeOp {
 
 func (t *metaType) Operand() dgo.Type {
 	return t.tp
+}
+
+func (t *metaType) ReflectType() reflect.Type {
+	return reflectTypeType
 }
 
 func (t *metaType) Resolve(ap dgo.AliasProvider) {

--- a/internal/meta_test.go
+++ b/internal/meta_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/lyraproj/dgo/dgo"
@@ -25,6 +26,8 @@ func TestMeta(t *testing.T) {
 	require.Equal(t, dgo.OpMeta, tp.(dgo.UnaryType).Operator())
 	require.Equal(t, `type`, tp.String())
 	require.Equal(t, `type[int]`, typ.Integer.Type().String())
+
+	require.True(t, reflect.ValueOf(typ.Any).Type().AssignableTo(tp.ReflectType()))
 }
 
 func TestMetaMeta(t *testing.T) {

--- a/internal/native.go
+++ b/internal/native.go
@@ -47,6 +47,10 @@ func (t *nativeType) HashCode() int {
 	return stringHash(t.rt.Name())*31 + int(dgo.TiNative)
 }
 
+func (t *nativeType) ReflectType() reflect.Type {
+	return t.rt
+}
+
 func (t *nativeType) Type() dgo.Type {
 	return &metaType{t}
 }
@@ -131,6 +135,17 @@ func structHash(rv *reflect.Value) int {
 		h = h*31 + ValueFromReflected(rv.Field(i)).HashCode()
 	}
 	return h
+}
+
+func (v native) ReflectTo(value reflect.Value) {
+	vr := reflect.Value(v)
+	if value.Kind() == reflect.Ptr {
+		p := reflect.New(vr.Type())
+		p.Elem().Set(vr)
+		value.Set(p)
+	} else {
+		value.Set(vr)
+	}
 }
 
 func (v native) String() string {

--- a/internal/native_test.go
+++ b/internal/native_test.go
@@ -73,6 +73,13 @@ func TestNative(t *testing.T) {
 	s, ok = vf.Value(&testStructNoStringer{`a`}).(dgo.Native)
 	require.True(t, ok)
 	require.Equal(t, `<*internal_test.testStructNoStringer Value>`, s.String())
+}
+
+func TestNativeType(t *testing.T) {
+	c, ok := vf.Value(make(chan bool)).(dgo.Native)
+	require.True(t, ok)
+	f, ok := vf.Value(reflect.ValueOf).(dgo.Native)
+	require.True(t, ok)
 
 	nt := f.Type()
 	ct := c.Type()
@@ -100,4 +107,27 @@ func TestNative(t *testing.T) {
 	require.NotEqual(t, 1234, internal.Native(reflect.ValueOf(&n)).HashCode())
 	require.Equal(t, 1234, internal.Native(reflect.ValueOf(n)).HashCode())
 	require.Equal(t, 1, internal.Native(reflect.ValueOf(n)).GoValue())
+
+	require.Equal(t, nt.ReflectType(), reflect.ValueOf(f.GoValue()).Type())
+}
+
+func TestNative_ReflectTo(t *testing.T) {
+	var c chan bool
+	v := vf.Value(make(chan bool)).(dgo.Native)
+	vf.ReflectTo(v, reflect.ValueOf(&c).Elem())
+	require.NotNil(t, c)
+	require.Equal(t, v, c)
+
+	var cp *chan bool
+	vf.ReflectTo(v, reflect.ValueOf(&cp).Elem())
+	require.NotNil(t, cp)
+	require.NotNil(t, *cp)
+	require.Equal(t, v, *cp)
+
+	var mi interface{}
+	mip := &mi
+	vf.ReflectTo(v, reflect.ValueOf(mip).Elem())
+	cc, ok := mi.(chan bool)
+	require.True(t, ok)
+	require.Equal(t, v, cc)
 }

--- a/internal/nil.go
+++ b/internal/nil.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"gopkg.in/yaml.v3"
 
@@ -44,6 +45,10 @@ func (nilValue) MarshalYAML() (interface{}, error) {
 	return &yaml.Node{Kind: yaml.ScalarNode, Tag: `!!null`, Value: `null`}, nil
 }
 
+func (nilValue) ReflectTo(value reflect.Value) {
+	value.Set(reflect.Zero(value.Type()))
+}
+
 func (nilValue) String() string {
 	return `null`
 }
@@ -73,6 +78,10 @@ func (t nilType) HashCode() int {
 
 func (t nilType) Instance(v interface{}) bool {
 	return Nil == v || nil == v
+}
+
+func (t nilType) ReflectType() reflect.Type {
+	return reflectAnyType
 }
 
 func (t nilType) Type() dgo.Type {

--- a/internal/nil_test.go
+++ b/internal/nil_test.go
@@ -1,6 +1,8 @@
 package internal_test
 
 import (
+	"errors"
+	"reflect"
 	"testing"
 
 	require "github.com/lyraproj/dgo/dgo_test"
@@ -8,7 +10,7 @@ import (
 	"github.com/lyraproj/dgo/vf"
 )
 
-func TestNil(t *testing.T) {
+func TestNil_CompareTo(t *testing.T) {
 	c, ok := vf.Nil.CompareTo(vf.Nil)
 	require.True(t, ok)
 	require.Equal(t, 0, c)
@@ -16,7 +18,25 @@ func TestNil(t *testing.T) {
 	c, ok = vf.Nil.CompareTo(vf.Integer(1))
 	require.True(t, ok)
 	require.Equal(t, -1, c)
+}
 
+func TestNil_ReflectTo(t *testing.T) {
+	err := errors.New(`some error`)
+	vf.Nil.ReflectTo(reflect.ValueOf(&err).Elem())
+	require.True(t, err == nil)
+
+	err = errors.New(`some error`)
+	ep := &err
+	vf.Nil.ReflectTo(reflect.ValueOf(&ep).Elem())
+	require.True(t, ep == nil)
+
+	var mi interface{} = err
+	mip := &mi
+	vf.Nil.ReflectTo(reflect.ValueOf(mip).Elem())
+	require.True(t, mi == nil)
+}
+
+func TestNilType(t *testing.T) {
 	nt := typ.Nil
 	require.Assignable(t, nt, nt)
 	require.Instance(t, nt, vf.Nil)
@@ -33,4 +53,6 @@ func TestNil(t *testing.T) {
 
 	require.NotEqual(t, 0, nt.HashCode())
 	require.Equal(t, nt.HashCode(), nt.HashCode())
+
+	require.Equal(t, nt.ReflectType(), typ.Any.ReflectType())
 }

--- a/internal/not.go
+++ b/internal/not.go
@@ -1,6 +1,10 @@
 package internal
 
-import "github.com/lyraproj/dgo/dgo"
+import (
+	"reflect"
+
+	"github.com/lyraproj/dgo/dgo"
+)
 
 type notType struct {
 	negated dgo.Type
@@ -77,6 +81,10 @@ func (t *notType) Operand() dgo.Type {
 
 func (t *notType) Operator() dgo.TypeOp {
 	return dgo.OpNot
+}
+
+func (t *notType) ReflectType() reflect.Type {
+	return reflectAnyType
 }
 
 func (t *notType) Resolve(ap dgo.AliasProvider) {

--- a/internal/not_test.go
+++ b/internal/not_test.go
@@ -46,4 +46,6 @@ func TestNotType(t *testing.T) {
 
 	require.Equal(t, `!nil`, notNil.String())
 	require.Equal(t, dgo.OpNot, notNil.Operator())
+
+	require.Equal(t, notNil.ReflectType(), typ.Any.ReflectType())
 }

--- a/internal/regexp.go
+++ b/internal/regexp.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -20,6 +21,8 @@ type (
 
 // DefaultRegexpType is the unconstrained Regexp type
 const DefaultRegexpType = regexpType(0)
+
+var reflectRegexpType = reflect.TypeOf(&regexp.Regexp{})
 
 func (t regexpType) Assignable(ot dgo.Type) bool {
 	switch ot.(type) {
@@ -43,6 +46,10 @@ func (t regexpType) Instance(v interface{}) bool {
 		_, ok = v.(*regexp.Regexp)
 	}
 	return ok
+}
+
+func (t regexpType) ReflectType() reflect.Type {
+	return reflectRegexpType
 }
 
 func (t regexpType) String() string {
@@ -86,6 +93,10 @@ func (t *exactRegexpType) IsInstance(v *regexp.Regexp) bool {
 	return (*regexp.Regexp)(t).String() == v.String()
 }
 
+func (t *exactRegexpType) ReflectType() reflect.Type {
+	return reflectRegexpType
+}
+
 func (t *exactRegexpType) String() string {
 	return TypeString(t)
 }
@@ -99,8 +110,7 @@ func (t *exactRegexpType) TypeIdentifier() dgo.TypeIdentifier {
 }
 
 func (t *exactRegexpType) Value() dgo.Value {
-	v := (*regexpVal)(t)
-	return v
+	return (*regexpVal)(t)
 }
 
 func (v *regexpVal) GoRegexp() *regexp.Regexp {
@@ -119,6 +129,15 @@ func (v *regexpVal) Equals(other interface{}) bool {
 
 func (v *regexpVal) HashCode() int {
 	return stringHash((*regexp.Regexp)(v).String())
+}
+
+func (v *regexpVal) ReflectTo(value reflect.Value) {
+	rv := reflect.ValueOf((*regexp.Regexp)(v))
+	k := value.Kind()
+	if !(k == reflect.Ptr || k == reflect.Interface) {
+		rv = rv.Elem()
+	}
+	value.Set(rv)
 }
 
 func (v *regexpVal) String() string {

--- a/internal/regexp_test.go
+++ b/internal/regexp_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -28,6 +29,8 @@ func TestRegexpDefault(t *testing.T) {
 	require.Instance(t, tp.Type(), tp)
 
 	require.Equal(t, `regexp`, tp.String())
+
+	require.True(t, reflect.ValueOf(r).Type().AssignableTo(tp.ReflectType()))
 }
 
 func TestRegexpExact(t *testing.T) {
@@ -50,6 +53,7 @@ func TestRegexpExact(t *testing.T) {
 	require.Instance(t, tp.Type(), tp)
 
 	require.Equal(t, `regexp["[a-z]+"]`, tp.String())
+	require.Equal(t, typ.Regexp.ReflectType(), tp.ReflectType())
 }
 
 func TestRegexp(t *testing.T) {
@@ -61,4 +65,23 @@ func TestRegexp(t *testing.T) {
 	require.NotEqual(t, rx, `[a-z]*`)
 	require.Same(t, rx, vf.Value(rx).(dgo.Regexp).GoRegexp())
 	require.NotEqual(t, vf.Float(3.14).ToFloat(), vf.Integer(3).ToFloat())
+}
+
+func TestRegexp_ReflectTo(t *testing.T) {
+	var ex *regexp.Regexp
+	v := vf.Value(regexp.MustCompile(`[a-z]+`))
+	vf.ReflectTo(v, reflect.ValueOf(&ex).Elem())
+	require.NotNil(t, ex)
+	require.Equal(t, v, ex)
+
+	var ev regexp.Regexp
+	vf.ReflectTo(v, reflect.ValueOf(&ev).Elem())
+	require.Equal(t, v, &ev)
+
+	var mi interface{}
+	mip := &mi
+	vf.ReflectTo(v, reflect.ValueOf(mip).Elem())
+	ec, ok := mi.(*regexp.Regexp)
+	require.True(t, ok)
+	require.Same(t, ex, ec)
 }

--- a/internal/string.go
+++ b/internal/string.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"reflect"
 	"regexp"
 	"strconv"
 
@@ -92,6 +93,10 @@ func (t defaultDgoStringType) Instance(value interface{}) (ok bool) {
 	return
 }
 
+func (t defaultDgoStringType) ReflectType() reflect.Type {
+	return reflectStringType
+}
+
 func (t defaultDgoStringType) TypeIdentifier() dgo.TypeIdentifier {
 	return dgo.TiDgoString
 }
@@ -113,6 +118,8 @@ const DefaultStringType = defaultStringType(0)
 
 // DefaultDgoStringType is the unconstrained Dgo String type
 const DefaultDgoStringType = defaultDgoStringType(0)
+
+var reflectStringType = reflect.TypeOf(` `)
 
 // EnumType returns a StringType that represents all of the given strings
 func EnumType(strings []string) dgo.Type {
@@ -173,6 +180,10 @@ func (t defaultStringType) String() string {
 	return TypeString(t)
 }
 
+func (t defaultStringType) ReflectType() reflect.Type {
+	return reflectStringType
+}
+
 func (t defaultStringType) Type() dgo.Type {
 	return &metaType{t}
 }
@@ -223,6 +234,10 @@ func (t *exactStringType) Min() int {
 
 func (t *exactStringType) String() string {
 	return TypeString(t)
+}
+
+func (t *exactStringType) ReflectType() reflect.Type {
+	return reflectStringType
 }
 
 func (t *exactStringType) Type() dgo.Type {
@@ -312,6 +327,10 @@ func (t *patternType) IsInstance(v string) bool {
 	return t.MatchString(v)
 }
 
+func (t *patternType) ReflectType() reflect.Type {
+	return reflectStringType
+}
+
 func (t *patternType) Type() dgo.Type {
 	return &metaType{t}
 }
@@ -396,6 +415,10 @@ func (t *sizedStringType) Max() int {
 
 func (t *sizedStringType) Min() int {
 	return t.min
+}
+
+func (t *sizedStringType) ReflectType() reflect.Type {
+	return reflectStringType
 }
 
 func (t *sizedStringType) String() string {
@@ -490,6 +513,17 @@ func (v *hstring) MarshalYAML() (interface{}, error) {
 	n := &yaml.Node{}
 	n.SetString(v.s)
 	return n, nil
+}
+
+func (v *hstring) ReflectTo(value reflect.Value) {
+	switch value.Kind() {
+	case reflect.Interface:
+		value.Set(reflect.ValueOf(v.s))
+	case reflect.Ptr:
+		value.Set(reflect.ValueOf(&v.s))
+	default:
+		value.SetString(v.s)
+	}
 }
 
 func (v *hstring) String() string {

--- a/internal/string_test.go
+++ b/internal/string_test.go
@@ -2,6 +2,7 @@ package internal_test
 
 import (
 	"math"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -51,6 +52,8 @@ func TestPattern(t *testing.T) {
 	require.Equal(t, `/a\u{14}b/`, newtype.Pattern(regexp.MustCompile(s)).String())
 
 	require.Equal(t, `/a\/b/`, newtype.Pattern(regexp.MustCompile(`a/b`)).String())
+
+	require.Equal(t, typ.String.ReflectType(), tp.ReflectType())
 }
 
 func TestStringDefault(t *testing.T) {
@@ -73,6 +76,8 @@ func TestStringDefault(t *testing.T) {
 	require.NotEqual(t, 0, tp.HashCode())
 
 	require.Equal(t, `string`, tp.String())
+
+	require.True(t, reflect.ValueOf(`hello`).Type().AssignableTo(typ.String.ReflectType()))
 }
 
 func TestStringExact(t *testing.T) {
@@ -103,6 +108,7 @@ func TestStringExact(t *testing.T) {
 	require.NotEqual(t, 0, tp.HashCode())
 
 	require.Equal(t, `"doh"`, tp.String())
+	require.Equal(t, typ.String.ReflectType(), tp.ReflectType())
 }
 
 func TestString_badOneArg(t *testing.T) {
@@ -170,6 +176,7 @@ func TestStringType(t *testing.T) {
 	require.NotEqual(t, 0, tp.HashCode())
 
 	require.Equal(t, `string[3,5]`, tp.String())
+	require.Equal(t, typ.String.ReflectType(), tp.ReflectType())
 }
 
 func TestDgoStringType(t *testing.T) {
@@ -199,6 +206,7 @@ func TestDgoStringType(t *testing.T) {
 	require.NotAssignable(t, typ.DgoString, vf.String(s).Type())
 
 	require.NotEqual(t, 0, typ.DgoString.HashCode())
+	require.Equal(t, typ.String.ReflectType(), typ.DgoString.ReflectType())
 }
 
 func TestString(t *testing.T) {

--- a/internal/struct.go
+++ b/internal/struct.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 
 	"github.com/lyraproj/dgo/util"
 
@@ -162,7 +163,7 @@ func (t *structType) DeepAssignable(guard dgo.RecursionGuard, other dgo.Type) bo
 		}
 		return t.additional || oc == len(oks)
 	case *exactMapType:
-		ov := (*hashMap)(ot)
+		ov := ot.value
 		return Instance(guard, t, ov)
 	}
 	return CheckAssignableTo(guard, other, t)
@@ -273,6 +274,10 @@ func (t *structType) Min() int {
 		}
 	}
 	return min
+}
+
+func (t *structType) ReflectType() reflect.Type {
+	return reflect.MapOf(t.KeyType().ReflectType(), t.ValueType().ReflectType())
 }
 
 func (t *structType) Resolve(ap dgo.AliasProvider) {

--- a/internal/struct_test.go
+++ b/internal/struct_test.go
@@ -3,6 +3,7 @@ package internal_test
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -183,6 +184,10 @@ func TestStructType(t *testing.T) {
 		newtype.Struct(false,
 			newtype.StructEntry(newtype.Pattern(regexp.MustCompile(`a*`)), typ.Integer, true))
 	}, `non exact key types`)
+
+	tps = newtype.Parse(`{a:0..10,b?:int}`).(dgo.StructType)
+	require.True(t, reflect.ValueOf(map[string]int64{}).Type().AssignableTo(tps.ReflectType()))
+
 }
 
 func TestStructEntry(t *testing.T) {

--- a/internal/structmap.go
+++ b/internal/structmap.go
@@ -1,0 +1,340 @@
+package internal
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/lyraproj/dgo/dgo"
+	"github.com/lyraproj/dgo/util"
+	"gopkg.in/yaml.v3"
+)
+
+type (
+	structMap struct {
+		rs     reflect.Value
+		frozen bool
+	}
+)
+
+func (v *structMap) String() string {
+	return ToStringERP(v)
+}
+
+func (v *structMap) Type() dgo.Type {
+	return &exactMapType{v}
+}
+
+func (v *structMap) Equals(other interface{}) bool {
+	return equals(nil, v, other)
+}
+
+func (v *structMap) deepEqual(seen []dgo.Value, other deepEqual) bool {
+	return mapEqual(seen, v, other)
+}
+
+func (v *structMap) HashCode() int {
+	return deepHashCode(nil, v)
+}
+
+func (v *structMap) deepHashCode(seen []dgo.Value) int {
+	h := 1
+	v.Each(func(e dgo.MapEntry) { h = h*31 + deepHashCode(seen, e) })
+	return h
+}
+
+func (v *structMap) Freeze() {
+	// Perform a shallow copy of the struct
+	if !v.frozen {
+		v.frozen = true
+		v.rs = reflect.ValueOf(v.rs.Interface())
+		v.EachValue(func(e dgo.Value) {
+			if f, ok := e.(dgo.Freezable); ok {
+				f.Freeze()
+			}
+		})
+	}
+}
+
+func (v *structMap) Frozen() bool {
+	return v.frozen
+}
+
+func (v *structMap) FrozenCopy() dgo.Value {
+	if v.frozen {
+		return v
+	}
+
+	// Perform a by-value copy of the struct
+	rs := reflect.New(v.rs.Type()).Elem() // create and dereference pointer to a zero value
+	rs.Set(v.rs)                          // copy v.rs to the zero value
+
+	for i, n := 0, rs.NumField(); i < n; i++ {
+		ef := rs.Field(i)
+		ev := ValueFromReflected(ef)
+		if f, ok := ev.(dgo.Freezable); ok && !f.Frozen() {
+			ReflectTo(f.FrozenCopy(), ef)
+		}
+	}
+	return &structMap{rs: rs, frozen: true}
+}
+
+func (v *structMap) AppendTo(w util.Indenter) {
+	appendMapTo(v, w)
+}
+
+func (v *structMap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.rs.Addr().Interface())
+}
+
+func (v *structMap) MarshalYAML() (interface{}, error) {
+	// A bit wasteful but this is currently the only way to create a yaml.Node
+	// from a struct
+	n := &yaml.Node{}
+	b, err := yaml.Marshal(v.rs.Addr().Interface())
+	if err == nil {
+		if err = yaml.Unmarshal(b, n); err == nil {
+			// n is the document node at this point.
+			n = n.Content[0]
+		}
+	}
+	return n, err
+}
+
+func (v *structMap) UnmarshalJSON(data []byte) error {
+	if v.frozen {
+		panic(frozenMap(`UnmarshalJSON`))
+	}
+	return json.Unmarshal(data, v.rs.Addr().Interface())
+}
+
+func (v *structMap) UnmarshalYAML(value *yaml.Node) error {
+	if v.frozen {
+		panic(frozenMap(`UnmarshalYAML`))
+	}
+	return value.Decode(v.rs.Addr().Interface())
+}
+
+func (v *structMap) All(predicate dgo.EntryPredicate) bool {
+	rv := v.rs
+	rt := rv.Type()
+	for i, n := 0, rt.NumField(); i < n; i++ {
+		if !predicate(&mapEntry{&hstring{s: rt.Field(i).Name}, ValueFromReflected(rv.Field(i))}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (v *structMap) AllKeys(predicate dgo.Predicate) bool {
+	rv := v.rs
+	rt := rv.Type()
+	for i, n := 0, rt.NumField(); i < n; i++ {
+		if !predicate(&hstring{s: rt.Field(i).Name}) {
+			return false
+		}
+	}
+	return true
+}
+
+func (v *structMap) AllValues(predicate dgo.Predicate) bool {
+	rv := v.rs
+	for i, n := 0, rv.NumField(); i < n; i++ {
+		if !predicate(ValueFromReflected(rv.Field(i))) {
+			return false
+		}
+	}
+	return true
+}
+
+func (v *structMap) Any(predicate dgo.EntryPredicate) bool {
+	return !v.All(func(entry dgo.MapEntry) bool { return !predicate(entry) })
+}
+
+func (v *structMap) AnyKey(predicate dgo.Predicate) bool {
+	return !v.AllKeys(func(entry dgo.Value) bool { return !predicate(entry) })
+}
+
+func (v *structMap) AnyValue(predicate dgo.Predicate) bool {
+	return !v.AllValues(func(entry dgo.Value) bool { return !predicate(entry) })
+}
+
+func (v *structMap) Copy(frozen bool) dgo.Map {
+	if frozen && v.frozen {
+		return v
+	}
+	if frozen {
+		return v.FrozenCopy().(dgo.Map)
+	}
+	// Thaw: Perform a by-value copy of the frozen struct
+	rs := reflect.New(v.rs.Type()).Elem() // create and dereference pointer to a zero value
+	rs.Set(v.rs)                          // copy v.rs to the zero value
+	return &structMap{rs: rs, frozen: false}
+}
+
+func (v *structMap) Each(doer dgo.EntryDoer) {
+	v.All(func(entry dgo.MapEntry) bool { doer(entry); return true })
+}
+
+func (v *structMap) EachKey(doer dgo.Doer) {
+	v.AllKeys(func(entry dgo.Value) bool { doer(entry); return true })
+}
+
+func (v *structMap) EachValue(doer dgo.Doer) {
+	v.AllValues(func(entry dgo.Value) bool { doer(entry); return true })
+}
+
+func (v *structMap) Entries() dgo.Array {
+	es := make([]dgo.Value, v.Len())
+	i := 0
+	v.Each(func(entry dgo.MapEntry) {
+		es[i] = entry
+		i++
+	})
+	return &array{slice: es, frozen: v.frozen}
+}
+
+func stringKey(key interface{}) (string, bool) {
+	if hs, ok := key.(*hstring); ok {
+		return hs.s, true
+	}
+	if s, ok := key.(string); ok {
+		return s, true
+	}
+	return ``, false
+}
+
+func (v *structMap) Get(key interface{}) dgo.Value {
+	if s, ok := stringKey(key); ok {
+		rv := v.rs
+		fv := rv.FieldByName(s)
+		if fv.IsValid() {
+			return ValueFromReflected(fv)
+		}
+	}
+	return nil
+}
+
+func (v *structMap) Keys() dgo.Array {
+	es := make([]dgo.Value, v.Len())
+	i := 0
+	v.EachKey(func(entry dgo.Value) {
+		es[i] = entry
+		i++
+	})
+	return &array{slice: es, frozen: true}
+}
+
+func (v *structMap) Len() int {
+	return v.rs.NumField()
+}
+
+func (v *structMap) Map(mapper dgo.EntryMapper) dgo.Map {
+	c := v.toHashMap()
+	for e := c.first; e != nil; e = e.next {
+		e.value = Value(mapper(e))
+	}
+	c.frozen = v.frozen
+	return c
+}
+
+func (v *structMap) Merge(associations dgo.Map) dgo.Map {
+	if associations.Len() == 0 || v == associations {
+		return v
+	}
+	c := v.toHashMap()
+	c.PutAll(associations)
+	c.frozen = v.frozen && associations.Frozen()
+	return c
+}
+
+func (v *structMap) Put(key, value interface{}) dgo.Value {
+	if v.frozen {
+		panic(frozenMap(`Put`))
+	}
+	if s, ok := stringKey(key); ok {
+		rv := v.rs
+		fv := rv.FieldByName(s)
+		if fv.IsValid() {
+			old := ValueFromReflected(fv)
+			ReflectTo(Value(value), fv)
+			return old
+		}
+	}
+	panic(fmt.Errorf(`%s has no field named '%s'`, v.rs.Type(), key))
+}
+
+func (v *structMap) PutAll(associations dgo.Map) {
+	associations.Each(func(e dgo.MapEntry) { v.Put(e.Key(), e.Value()) })
+}
+
+func (v *structMap) ReflectTo(value reflect.Value) {
+	if value.Kind() == reflect.Ptr {
+		if v.frozen {
+			// Don't expose pointer to frozen struct
+			rs := reflect.New(v.rs.Type()) // create pointer to a zero value
+			rs.Elem().Set(v.rs)            // copy v.rs to the zero value
+			value.Set(rs)
+		} else {
+			value.Set(v.rs.Addr())
+		}
+	} else {
+		// copy struct by value
+		value.Set(v.rs)
+	}
+}
+
+func (v *structMap) Remove(key interface{}) dgo.Value {
+	panic(errors.New(`struct fields cannot be removed`))
+}
+
+func (v *structMap) RemoveAll(keys dgo.Array) {
+	panic(errors.New(`struct fields cannot be removed`))
+}
+
+func (v *structMap) SetType(t interface{}) {
+	panic(errors.New(`struct type is read only`))
+}
+
+func (v *structMap) Values() dgo.Array {
+	es := make([]dgo.Value, v.Len())
+	i := 0
+	v.EachValue(func(entry dgo.Value) {
+		es[i] = entry
+		i++
+	})
+	return &array{slice: es, frozen: v.frozen}
+}
+
+func (v *structMap) With(key, value interface{}) dgo.Map {
+	c := v.toHashMap()
+	c.Put(key, value)
+	c.frozen = v.frozen
+	return c
+}
+
+func (v *structMap) Without(key interface{}) dgo.Map {
+	if v.Get(key) == nil {
+		return v
+	}
+	c := v.toHashMap()
+	c.Remove(key)
+	c.frozen = v.frozen
+	return c
+}
+
+func (v *structMap) WithoutAll(keys dgo.Array) dgo.Map {
+	c := v.toHashMap()
+	c.RemoveAll(keys)
+	c.frozen = v.frozen
+	return c
+}
+
+func (v *structMap) toHashMap() *hashMap {
+	c := MapWithCapacity(int(float64(v.Len())/loadFactor), nil)
+	v.Each(func(entry dgo.MapEntry) {
+		c.Put(entry.Key(), entry.Value())
+	})
+	return c.(*hashMap)
+}

--- a/internal/structmap_test.go
+++ b/internal/structmap_test.go
@@ -1,0 +1,532 @@
+package internal_test
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/lyraproj/dgo/dgo"
+	require "github.com/lyraproj/dgo/dgo_test"
+	"github.com/lyraproj/dgo/vf"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_structMap_Any(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	require.False(t, m.Any(func(e dgo.MapEntry) bool {
+		return e.Key().Equals(`Fourth`)
+	}))
+	require.True(t, m.Any(func(e dgo.MapEntry) bool {
+		return e.Key().Equals(`Second`) && e.Value().Equals(2.0)
+	}))
+}
+
+func Test_structMap_AllKeys(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	require.False(t, m.AllKeys(func(k dgo.Value) bool {
+		return len(k.String()) == 5
+	}))
+	require.True(t, m.AnyKey(func(k dgo.Value) bool {
+		return len(k.String()) >= 5
+	}))
+}
+
+func Test_structMap_AnyKey(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	require.False(t, m.AnyKey(func(k dgo.Value) bool {
+		return k.Equals(`Fourth`)
+	}))
+	require.True(t, m.AnyKey(func(k dgo.Value) bool {
+		return k.Equals(`Second`)
+	}))
+}
+
+func Test_structMap_AnyValue(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	require.False(t, m.AnyValue(func(v dgo.Value) bool {
+		return v.Equals(`four`)
+	}))
+	require.True(t, m.AnyValue(func(v dgo.Value) bool {
+		return v.Equals(`three`)
+	}))
+}
+
+func Test_structMap_Copy(t *testing.T) {
+	type structA struct {
+		A string
+		E dgo.Array
+	}
+	s := structA{A: `Alpha`}
+	m := vf.Map(&s)
+	m.Put(`E`, vf.MutableValues(nil, `Echo`, `Foxtrot`))
+
+	c := m.Copy(true).(dgo.Map)
+	require.False(t, m.Frozen())
+	require.False(t, m.Get(`E`).(dgo.Freezable).Frozen())
+	require.True(t, c.Frozen())
+	require.True(t, c.Get(`E`).(dgo.Freezable).Frozen())
+
+	m.Put(`A`, `Adam`)
+	require.Equal(t, `Adam`, m.Get(`A`))
+	require.Equal(t, `Alpha`, c.Get(`A`))
+	require.Same(t, c, c.Copy(true))
+
+	require.Panic(t, func() { c.Put(`A`, `Adam`) }, `frozen`)
+
+	d := c.Copy(false).(dgo.Map)
+	require.NotSame(t, c, d)
+	d.Put(`A`, `Adam`)
+	require.Equal(t, `Adam`, d.Get(`A`))
+	require.Equal(t, `Alpha`, c.Get(`A`))
+}
+
+func Test_structMap_EachKey(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	var vs []dgo.Value
+	m.EachKey(func(v dgo.Value) {
+		vs = append(vs, v)
+	})
+
+	require.Equal(t, 3, len(vs))
+	require.Equal(t, vf.Values(`First`, `Second`, `Third`), vs)
+}
+
+func Test_structMap_EachValue(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	var vs []dgo.Value
+	m.EachValue(func(v dgo.Value) {
+		vs = append(vs, v)
+	})
+
+	require.Equal(t, 3, len(vs))
+	require.Equal(t, vf.Values(1, 2.0, `three`), vs)
+}
+
+func Test_structMap_Entries(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+	var vs []dgo.Value
+	m.Entries().Each(func(v dgo.Value) {
+		e := v.(dgo.MapEntry)
+		vs = append(vs, e.Key())
+		vs = append(vs, e.Value())
+	})
+
+	require.Equal(t, 6, len(vs))
+	require.Equal(t, vf.Values(`First`, 1, `Second`, 2.0, `Third`, `three`), vs)
+}
+
+func Test_structMap_Get(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+		C *string
+		D *int
+		E []string
+	}
+	c := `Charlie`
+	s := structA{A: `Alpha`, B: 32, C: &c, E: []string{`Echo`, `Foxtrot`}}
+	m := vf.Map(&s)
+	require.Equal(t, m.Get(`A`), `Alpha`)
+	require.Equal(t, m.Get(`B`), 32)
+	require.Equal(t, m.Get(`C`), c)
+	require.Equal(t, m.Get(`D`), vf.Nil)
+	require.Equal(t, m.Get(`E`), []string{`Echo`, `Foxtrot`})
+	require.Equal(t, m.Get(`F`), nil)
+	require.Equal(t, m.Get(10), nil)
+}
+
+func Test_structMap_Freeze(t *testing.T) {
+	type structA struct {
+		A string
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	m.Freeze()
+	require.Panic(t, func() { m.Put(`A`, `Alpha`) }, `frozen`)
+}
+
+func Test_structMap_FrozenCopy(t *testing.T) {
+	type structA struct {
+		A string
+		E dgo.Array
+	}
+	s := structA{A: `Alpha`}
+	m := vf.Map(&s)
+	m.Put(`E`, vf.MutableValues(nil, `Echo`, `Foxtrot`))
+
+	c := m.FrozenCopy().(dgo.Map)
+	require.False(t, m.Frozen())
+	require.False(t, m.Get(`E`).(dgo.Freezable).Frozen())
+	require.True(t, c.Frozen())
+	require.True(t, c.Get(`E`).(dgo.Freezable).Frozen())
+
+	m.Put(`A`, `Adam`)
+	require.Equal(t, `Adam`, m.Get(`A`))
+	require.Equal(t, `Alpha`, c.Get(`A`))
+	require.Same(t, c, c.FrozenCopy())
+
+	require.Panic(t, func() { c.Put(`A`, `Adam`) }, `frozen`)
+}
+
+func Test_structMap_HashCode(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+	}
+	s := structA{A: `Alpha`, B: 32}
+	m := vf.Map(&s)
+	require.NotEqual(t, 0, m.HashCode())
+	require.Equal(t, m.HashCode(), m.HashCode())
+}
+
+func Test_structMap_Keys(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+		C *string
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	require.Equal(t, vf.Strings(`A`, `B`, `C`), m.Keys())
+}
+
+func Test_structMap_Map(t *testing.T) {
+	type structA struct {
+		A string
+		B string
+		C string
+	}
+	a := vf.Map(&structA{A: `value a`, B: `value b`, C: `value c`})
+	require.Equal(t, vf.Map(map[string]string{`A`: `the a`, `B`: `the b`, `C`: `the c`}), a.Map(func(e dgo.MapEntry) interface{} {
+		return strings.Replace(e.Value().String(), `value`, `the`, 1)
+	}))
+	require.Equal(t, vf.Map(`A`, nil, `B`, vf.Nil, `C`, nil), a.Map(func(e dgo.MapEntry) interface{} {
+		return nil
+	}))
+}
+
+func Test_structMap_MarshalJSON(t *testing.T) {
+	type structA struct {
+		A string `json:"a"`
+		B int    `json:"b"`
+	}
+	s := structA{A: `Alpha`, B: 32}
+	m := vf.Map(&s)
+	j, err := m.MarshalJSON()
+	require.Ok(t, err)
+	require.Equal(t, `{"a":"Alpha","b":32}`, string(j))
+}
+
+func Test_structMap_MarshalYAML(t *testing.T) {
+	type structA struct {
+		A string `json:"a"`
+		B int    `json:"b"`
+	}
+
+	type structAyaml struct {
+		A string `yaml:"a"`
+		B int    `yaml:"b"`
+	}
+
+	s := structA{A: `Alpha`, B: 32}
+	m := vf.Map(&s)
+	j, err := yaml.Marshal(m)
+	require.Ok(t, err)
+	require.Equal(t, `a: Alpha
+b: 32
+`, string(j))
+
+	s2 := structAyaml{A: `Alpha`, B: 32}
+	m = vf.Map(&s2)
+	j, err = yaml.Marshal(m)
+	require.Ok(t, err)
+	require.Equal(t, `a: Alpha
+b: 32
+`, string(j))
+
+	m = vf.Map(`nested`, m)
+	j, err = yaml.Marshal(m)
+	require.Ok(t, err)
+	require.Equal(t, `nested:
+    a: Alpha
+    b: 32
+`, string(j))
+}
+
+func Test_structMap_Merge(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m1 := vf.Map(&structA{1, 2.0, `three`})
+
+	m2 := vf.Map(
+		`Third`, `tres`,
+		`Fourth`, `cuatro`)
+
+	require.Equal(t, m1.Merge(m2), vf.Map(
+		`First`, 1,
+		`Second`, 2.0,
+		`Third`, `tres`,
+		`Fourth`, `cuatro`))
+
+	require.Same(t, m1, m1.Merge(m1))
+	require.Same(t, m1, m1.Merge(vf.Map()))
+	require.Same(t, m1, vf.Map().Merge(m1))
+}
+
+func Test_structMap_Put(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+		C *string
+		D *int
+		E []string
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	m.Put(`A`, `Alpha`)
+	m.Put(`B`, 32)
+	m.Put(`C`, `Charlie`)
+	m.Put(`D`, 42)
+	m.Put(`E`, []string{`Echo`, `Foxtrot`})
+
+	require.Panic(t, func() { m.Put(`F`, `nope`) }, `no field named 'F'`)
+
+	require.Equal(t, s.A, `Alpha`)
+	require.Equal(t, s.B, 32)
+	require.Equal(t, *s.C, `Charlie`)
+	require.Equal(t, *s.D, 42)
+	require.Equal(t, s.E, []string{`Echo`, `Foxtrot`})
+}
+
+func Test_structMap_PutAll(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	m.PutAll(vf.Map(`A`, `Alpha`, `B`, 32))
+	require.Equal(t, s.A, `Alpha`)
+	require.Equal(t, s.B, 32)
+}
+
+func Test_structMap_ReflectTo(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+		C *string
+		D *int
+		E []string
+	}
+
+	type structB struct {
+		A string
+		B *structA
+		C structA
+	}
+
+	c := `Charlie`
+	d := 42
+	s := structA{A: `Alpha`, B: 32, C: &c, D: &d, E: []string{`Echo`, `Foxtrot`}}
+
+	// Pass pointer to struct
+	m := vf.Map(&s)
+
+	x := structB{}
+	rv := reflect.ValueOf(&x).Elem()
+
+	// By pointer
+	xb := rv.FieldByName(`B`)
+	m.ReflectTo(xb)
+	require.Equal(t, x.B, &s)
+	require.Same(t, x.B, &s)
+
+	// By value
+	m.ReflectTo(rv.FieldByName(`C`))
+	require.Equal(t, &x.C, &s)
+	require.NotSame(t, &x.C, &s)
+
+	m.Freeze()
+	m.ReflectTo(xb)
+	require.NotSame(t, &x.B, &s)
+}
+
+func Test_structMap_Remove(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	require.Panic(t, func() { m.Remove(`B`) }, `cannot be removed`)
+	require.Panic(t, func() { m.RemoveAll(vf.Values(`A`, `B`)) }, `cannot be removed`)
+}
+
+func Test_structMap_SetType(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	require.Panic(t, func() { m.SetType(`map[string]int`) }, `type is read only`)
+}
+
+func Test_structMap_String(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+	}
+	s := structA{A: `Alpha`, B: 32}
+	m := vf.Map(&s)
+	require.Equal(t, `{"A":"Alpha","B":32}`, m.String())
+}
+
+func Test_structMap_Type(t *testing.T) {
+	type structA struct {
+		A string
+		B int
+	}
+	s := structA{A: `Alpha`, B: 32}
+	m := vf.Map(&s)
+	tp := m.Type()
+	require.Assignable(t, tp, tp)
+	require.Instance(t, tp, m)
+}
+
+func Test_structMap_UnmarshalJSON(t *testing.T) {
+	type structA struct {
+		A string `json:"a"`
+		B int    `json:"b"`
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	require.Ok(t, m.UnmarshalJSON([]byte(`{"a":"Adam","b":38}`)))
+	require.Equal(t, s.A, `Adam`)
+	require.Equal(t, s.B, 38)
+
+	m.Freeze()
+	require.Panic(t, func() { _ = json.Unmarshal([]byte(`{"b":"two"}`), m) }, `UnmarshalJSON .* frozen`)
+}
+
+func Test_structMap_UnmarshalYAML(t *testing.T) {
+	type structA struct {
+		A string `yaml:"a"`
+		B int    `yaml:"b"`
+	}
+	s := structA{}
+	m := vf.Map(&s)
+	require.Ok(t, yaml.Unmarshal([]byte(`a: Adam
+b: 38
+`), m))
+	require.Equal(t, s.A, `Adam`)
+	require.Equal(t, s.B, 38)
+
+	m.Freeze()
+	require.Panic(t, func() { _ = yaml.Unmarshal([]byte(`{"b":"two"}`), m) }, `UnmarshalYAML .* frozen`)
+}
+
+func Test_structMap_Values(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	m := vf.Map(&structA{1, 2.0, `three`})
+
+	require.True(t, m.Values().SameValues(vf.Values(1, 2.0, `three`)))
+}
+
+func Test_structMap_With(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	om := vf.Map(&structA{1, 2.0, `three`})
+	m := om.With(`Fourth`, `quad`)
+	require.Equal(t, m, vf.Map(`First`, 1, `Second`, 2.0, `Third`, `three`, `Fourth`, `quad`))
+}
+
+func Test_structMap_Without(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	om := vf.Map(&structA{1, 2.0, `three`})
+	m := om.Without(`Second`)
+	require.Equal(t, m, map[string]interface{}{
+		`First`: 1,
+		`Third`: `three`,
+	})
+
+	// Original is not modified
+	require.Equal(t, om, map[string]interface{}{
+		`First`:  1,
+		`Second`: 2.0,
+		`Third`:  `three`,
+	})
+
+	m = om.Without(`NotPresent`)
+	require.Same(t, m, om)
+}
+
+func Test_structMap_WithoutAll(t *testing.T) {
+	type structA struct {
+		First  int
+		Second float64
+		Third  string
+	}
+	om := vf.Map(&structA{1, 2.0, `three`})
+	m := om.WithoutAll(vf.Strings(`First`, `Second`))
+	require.Equal(t, m, map[string]interface{}{
+		`Third`: `three`,
+	})
+
+	// Original is not modified
+	require.Equal(t, om, map[string]interface{}{
+		`First`:  1,
+		`Second`: 2.0,
+		`Third`:  `three`,
+	})
+}

--- a/internal/ternary_test.go
+++ b/internal/ternary_test.go
@@ -40,6 +40,8 @@ func TestAllOfType(t *testing.T) {
 
 	require.Equal(t, `("a"|"b"|"c")&("b"|"c"|"d")`, tp.String())
 
+	require.Equal(t, typ.String.ReflectType(), tp.ReflectType())
+
 	tp = newtype.AllOf(newtype.Pattern(regexp.MustCompile(`a`)), newtype.Pattern(regexp.MustCompile(`b`)), newtype.Pattern(regexp.MustCompile(`c`)))
 	require.Instance(t, tp, `abc`)
 	require.NotInstance(t, tp, `c`)
@@ -83,6 +85,8 @@ func TestAnyOfType(t *testing.T) {
 	require.Equal(t, tp.(dgo.TernaryType).Operator(), dgo.OpOr)
 
 	require.Equal(t, `int|string`, tp.String())
+
+	require.Equal(t, typ.Any.ReflectType(), tp.ReflectType())
 }
 
 func TestOneOfType(t *testing.T) {
@@ -117,6 +121,7 @@ func TestOneOfType(t *testing.T) {
 	require.Equal(t, tp.(dgo.TernaryType).Operator(), dgo.OpOne)
 
 	require.Equal(t, `int^/a/^/b/`, tp.String())
+	require.Equal(t, typ.Any.ReflectType(), tp.ReflectType())
 }
 
 func TestEnum(t *testing.T) {

--- a/internal/value.go
+++ b/internal/value.go
@@ -7,6 +7,8 @@ import (
 	"github.com/lyraproj/dgo/dgo"
 )
 
+var reflectValueType = reflect.TypeOf((*dgo.Value)(nil)).Elem()
+
 // Value returns the dgo.Value representation of its argument
 func Value(v interface{}) dgo.Value {
 	// This function is kept very small to enable inlining so this
@@ -90,6 +92,17 @@ func ValueFromReflected(vr reflect.Value) dgo.Value {
 	}
 	// Value as unsafe. Immutability is not guaranteed
 	return native(vr)
+}
+
+// ReflectTo assigns the given dgo.Value to the given reflect.Value
+func ReflectTo(src dgo.Value, dest reflect.Value) {
+	if !dest.Type().AssignableTo(reflectValueType) {
+		if rv, ok := src.(dgo.ReflectedValue); ok {
+			rv.ReflectTo(dest)
+			return
+		}
+	}
+	dest.Set(reflect.ValueOf(src))
 }
 
 // Add well known types like regexp, time, etc. here

--- a/vf/primitive.go
+++ b/vf/primitive.go
@@ -61,3 +61,8 @@ func Value(v interface{}) dgo.Value {
 func ValueFromReflected(v reflect.Value) dgo.Value {
 	return internal.ValueFromReflected(v)
 }
+
+// ReflectTo assigns the given dgo.Value to the given reflect.Value
+func ReflectTo(src dgo.Value, dest reflect.Value) {
+	internal.ReflectTo(src, dest)
+}


### PR DESCRIPTION
This commit introduces a new Dgo value that wraps a Go struct.
It also introduces a new ReflectTo method that allows values to assign
themselves to a reflect.Value.