### PR TITLE
Improve stringer to handle aliases …

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/dgo/named.go
+++ b/dgo/named.go
@@ -36,7 +36,7 @@ type (
 		ValueString(value Value) string
 	}
 
-	// NamedType is implemented by types that are named and made available using an AliasMap
+	// NamedType is implemented by types that are named and made available using an AliasAdder
 	NamedType interface {
 		Type
 		NamedTypeExtension

--- a/dgo/type.go
+++ b/dgo/type.go
@@ -131,10 +131,10 @@ type (
 	//
 	// The parser uses this interface to perform in-place replacement of aliases
 	AliasContainer interface {
-		Resolve(AliasMap)
+		Resolve(AliasAdder)
 	}
 
-	// Alias is a named reference of another type which can be resolved using an AliasMap
+	// Alias is a named reference of another type which can be resolved using an AliasAdder
 	Alias interface {
 		Type
 
@@ -142,21 +142,30 @@ type (
 		Reference() String
 	}
 
+	// An AliasAdder maintains mappings of names to types
+	AliasAdder interface {
+		// Add adds the type t with the given name to this map
+		Add(t Type, name String)
+
+		// GetType returns the type with the given name or nil if the type isn't found
+		GetType(n String) Type
+
+		// Replace replaces aliases with their concrete value.
+		Replace(Value) Value
+	}
+
 	// An AliasMap maps names to types and vice versa.
 	AliasMap interface {
+		// Collect is used to collect new aliases in a manner that is safe from a concurrency standpoint. If
+		// new aliases were added by the given function argument, it returns a new fully resolved AliasAdder,
+		// otherwise it returns itself.
+		Collect(func(AliasAdder)) AliasMap
+
 		// GetName returns the name for the given type or nil if the type isn't found
 		GetName(t Type) String
 
 		// GetType returns the type with the given name or nil if the type isn't found
 		GetType(n String) Type
-
-		// Add adds the type t with the given name to this map
-		Add(t Type, name String)
-
-		// Replace replaces aliases with their concrete value.
-		//
-		// The parser uses this interface to perform in-place replacement of aliases
-		Replace(Value) Value
 	}
 
 	// GenericType is implemented by types that represent themselves stripped from

--- a/dgo/typeidentifier.go
+++ b/dgo/typeidentifier.go
@@ -145,6 +145,7 @@ const (
 )
 
 var tiLabels = map[TypeIdentifier]string{
+	TiAlias:         `alias`,
 	TiNil:           `nil`,
 	TiAny:           `any`,
 	TiMeta:          `type`,

--- a/internal/alias.go
+++ b/internal/alias.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/lyraproj/dgo/dgo"
 )
@@ -16,12 +17,49 @@ type (
 		namedTypes hashMap
 	}
 
+	aliasAdder struct {
+		namedTypes hashMap
+		backingMap *aliasMap
+	}
+
 	dType        = dgo.Type // To avoid collision with method named Type
 	deferredCall struct {
 		dType
 		args dgo.Arguments
 	}
 )
+
+// BuiltInAliases returns a frozen AliasMap containing the predefined aliases
+func BuiltInAliases() dgo.AliasMap {
+	return builtinAliases
+}
+
+var defaultLock = sync.Mutex{}
+
+// AddDefaultAliases adds the new aliases to the default alias map by passing an AliasAdder to the function
+// The function is safe from a concurrency perspective.
+func AddDefaultAliases(adder func(adder dgo.AliasAdder)) {
+	am := &aliasAdder{backingMap: defaultAliases.(*aliasMap)}
+	adder(am)
+	if am.namedTypes.Len() > 0 {
+		defaultLock.Lock()
+		defer defaultLock.Unlock()
+		defaultAliases = am.backingMap.update(am)
+	}
+}
+
+// DefaultAliases returns the frozen default dgo.AliasMap
+func DefaultAliases() dgo.AliasMap {
+	return defaultAliases
+}
+
+// ResetDefaultAliases will reset the AliasMap returned by the DefaultAliases() method to the BuiltInAliases()
+// and thereby throw away any changes made to the DefaultAliases map.
+//
+// This method is intended for testing purposes only
+func ResetDefaultAliases() {
+	defaultAliases = builtinAliases
+}
 
 // NewCall creates a special interim type that represents a call during parsing, and then nowhere else.
 func NewCall(s dgo.Type, args dgo.Arguments) dgo.Type {
@@ -33,6 +71,25 @@ func NewAlias(s dgo.String) dgo.Alias {
 	return &alias{s.Type().(dgo.StringType)}
 }
 
+// Freeze will panic. The reason for this is that an alias is a type reference and as such, it may be replaced by
+// an actual type when an AliasContainer is resolved. An AliasContainer in turn, can be used as a key in a hash. When
+// it does, all its aliases must have been replaced or the hash code of the container will change.
+func (a *alias) Freeze() {
+	panic(a.freezeAttempt())
+}
+
+func (a *alias) Frozen() bool {
+	return false
+}
+
+func (a *alias) FrozenCopy() dgo.Value {
+	panic(a.freezeAttempt())
+}
+
+func (a *alias) freezeAttempt() error {
+	return fmt.Errorf(`attempt to freeze unresolved alias '%s'`, a.Reference())
+}
+
 func (a *alias) Reference() dgo.String {
 	return a.StringType.(dgo.ExactType).ExactValue().(dgo.String)
 }
@@ -41,50 +98,75 @@ func (a *alias) TypeIdentifier() dgo.TypeIdentifier {
 	return dgo.TiAlias
 }
 
-var builtinAliases *aliasMap
+var builtinAliases dgo.AliasMap
+var defaultAliases dgo.AliasMap
 
 func init() {
-	m := &aliasMap{}
-	dataAlias := NewAlias(String(`data`))
-	data := AnyOfType([]interface{}{
-		DefaultStringType,
-		DefaultIntegerType,
-		DefaultFloatType,
-		DefaultBooleanType,
-		DefaultNilType,
-		ArrayType([]interface{}{dataAlias}),
-		MapType([]interface{}{DefaultStringType, dataAlias})})
-	m.Add(data, dataAlias.Reference())
+	m := (&aliasMap{}).Collect(func(b dgo.AliasAdder) {
+		dataAlias := NewAlias(String(`data`))
+		data := AnyOfType([]interface{}{
+			DefaultStringType,
+			DefaultIntegerType,
+			DefaultFloatType,
+			DefaultBooleanType,
+			DefaultNilType,
+			ArrayType([]interface{}{dataAlias}),
+			MapType([]interface{}{DefaultStringType, dataAlias})})
+		b.Add(data, dataAlias.Reference())
 
-	richDataAlias := NewAlias(String(`richdata`))
-	richData := AnyOfType([]interface{}{
-		DefaultStringType,
-		DefaultIntegerType,
-		DefaultFloatType,
-		DefaultBooleanType,
-		DefaultBinaryType,
-		DefaultMetaType,
-		DefaultRegexpType,
-		DefaultSensitiveType,
-		DefaultTimeType,
-		DefaultNilType,
-		ArrayType([]interface{}{richDataAlias}),
-		MapType([]interface{}{AnyOfType([]interface{}{DefaultStringType, DefaultIntegerType, DefaultFloatType}), richDataAlias})})
-	m.Add(richData, richDataAlias.Reference())
-
-	data.(dgo.AliasContainer).Resolve(m)
-	richData.(dgo.AliasContainer).Resolve(m)
+		richDataAlias := NewAlias(String(`richdata`))
+		richData := AnyOfType([]interface{}{
+			DefaultStringType,
+			DefaultIntegerType,
+			DefaultFloatType,
+			DefaultBooleanType,
+			DefaultBinaryType,
+			DefaultMetaType,
+			DefaultRegexpType,
+			DefaultSensitiveType,
+			DefaultTimeType,
+			DefaultNilType,
+			ArrayType([]interface{}{richDataAlias}),
+			MapType([]interface{}{AnyOfType([]interface{}{DefaultStringType, DefaultIntegerType, DefaultFloatType}), richDataAlias})})
+		b.Add(richData, richDataAlias.Reference())
+	})
 	builtinAliases = m
+	defaultAliases = m
 }
 
-// NewAliasMap creates a new dgo.AliasMap to be used as a scope when parsing types
-func NewAliasMap() dgo.AliasMap {
-	m := &aliasMap{}
-	builtinAliases.namedTypes.resize(&m.namedTypes, 0)
-	builtinAliases.typeNames.resize(&m.typeNames, 0)
-	return m
+func (a *aliasMap) Collect(adder func(dgo.AliasAdder)) dgo.AliasMap {
+	am := &aliasAdder{backingMap: a}
+	adder(am)
+	if am.namedTypes.Len() > 0 {
+		return a.update(am)
+	}
+	return a
 }
 
+func (a *aliasMap) update(am *aliasAdder) dgo.AliasMap {
+	// Create a new alias map with enough room to fit the new entries
+	c := &aliasMap{}
+	ns := am.namedTypes
+	na := ns.Len()
+	a.namedTypes.resize(&c.namedTypes, na)
+	a.typeNames.resize(&c.typeNames, na)
+
+	// Resolve the added entries
+	rs := ns.Map(func(e dgo.MapEntry) interface{} { return am.Replace(e.Value()) })
+
+	// Add entries to the new alias map
+	rs.EachEntry(func(e dgo.MapEntry) {
+		name := e.Key().(dgo.String)
+		t := e.Value().(dgo.Type)
+		c.namedTypes.Put(name, t)
+		c.typeNames.Put(t, name)
+	})
+	c.namedTypes.Freeze()
+	c.typeNames.Freeze()
+	return c
+}
+
+// GetName returns the name for the given type or nil if the type isn't found
 func (a *aliasMap) GetName(t dgo.Type) dgo.String {
 	if v := a.typeNames.Get(t); v != nil {
 		return v.(dgo.String)
@@ -92,6 +174,7 @@ func (a *aliasMap) GetName(t dgo.Type) dgo.String {
 	return nil
 }
 
+// GetType returns the type with the given name or nil if the type isn't found
 func (a *aliasMap) GetType(n dgo.String) dgo.Type {
 	if v := a.namedTypes.Get(n); v != nil {
 		return v.(dgo.Type)
@@ -99,12 +182,18 @@ func (a *aliasMap) GetType(n dgo.String) dgo.Type {
 	return nil
 }
 
-func (a *aliasMap) Add(t dgo.Type, name dgo.String) {
-	a.typeNames.Put(t, name)
+func (a *aliasAdder) Add(t dgo.Type, name dgo.String) {
 	a.namedTypes.Put(name, t)
 }
 
-func (a *aliasMap) Replace(t dgo.Value) dgo.Value {
+func (a *aliasAdder) GetType(n dgo.String) dgo.Type {
+	if t := a.namedTypes.Get(n); t != nil {
+		return t.(dgo.Type)
+	}
+	return a.backingMap.GetType(n)
+}
+
+func (a *aliasAdder) Replace(t dgo.Value) dgo.Value {
 	switch t := t.(type) {
 	case *deferredCall:
 		return New(t.dType, t.args)

--- a/internal/alias_test.go
+++ b/internal/alias_test.go
@@ -3,15 +3,43 @@ package internal_test
 import (
 	"testing"
 
+	"github.com/lyraproj/dgo/parser"
+
+	"github.com/lyraproj/dgo/dgo"
+
+	"github.com/lyraproj/dgo/vf"
+
 	require "github.com/lyraproj/dgo/dgo_test"
 	"github.com/lyraproj/dgo/typ"
 
 	"github.com/lyraproj/dgo/tf"
 )
 
+func TestAlias_Freeze(t *testing.T) {
+	alias := parser.NewAlias(vf.String(`hello`)).(dgo.Freezable)
+	require.False(t, alias.Frozen())
+	require.Panic(t, func() {
+		alias.Freeze()
+	}, `attempt to freeze unresolved alias`)
+	require.Panic(t, func() {
+		alias.FrozenCopy()
+	}, `attempt to freeze unresolved alias`)
+}
+
 func TestAliasMap_Get(t *testing.T) {
-	am := tf.NewAliasMap()
-	tf.ParseFile(am, `example.dgo`, `a=string[1]`)
+	am := tf.BuiltInAliases().Collect(func(a dgo.AliasAdder) {
+		tf.ParseFile(a, `example.dgo`, `a=string[1]`)
+	})
 	require.Equal(t, `a`, am.GetName(tf.String(1)))
 	require.Nil(t, am.GetName(typ.String))
+}
+
+func TestDefaultAliasMap_Get(t *testing.T) {
+	rd := vf.String(`richData`)
+	require.Equal(t, tf.DefaultAliases().GetType(rd), tf.BuiltInAliases().GetType(rd))
+}
+
+func TestAddDefaultAliases(t *testing.T) {
+	rd := vf.String(`richData`)
+	require.Equal(t, tf.DefaultAliases().GetType(rd), tf.BuiltInAliases().GetType(rd))
 }

--- a/internal/alias_test.go
+++ b/internal/alias_test.go
@@ -1,6 +1,7 @@
 package internal_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/lyraproj/dgo/parser"
@@ -42,4 +43,20 @@ func TestDefaultAliasMap_Get(t *testing.T) {
 func TestAddDefaultAliases(t *testing.T) {
 	rd := vf.String(`richData`)
 	require.Equal(t, tf.DefaultAliases().GetType(rd), tf.BuiltInAliases().GetType(rd))
+}
+
+func TestAddAliases(t *testing.T) {
+	lock := sync.Mutex{}
+	bi := tf.BuiltInAliases()
+	aliases := bi
+	tf.AddAliases(&aliases, &lock, func(aa dgo.AliasAdder) {
+	})
+	require.Same(t, bi, aliases)
+
+	tf.AddAliases(&aliases, &lock, func(aa dgo.AliasAdder) {
+		aa.Add(tf.String(10, 12), vf.String(`pnr`))
+	})
+	require.NotSame(t, bi, aliases)
+	require.Equal(t, aliases.GetType(vf.String(`pnr`)), tf.String(10, 12))
+	require.Nil(t, bi.GetType(vf.String(`pnr`)))
 }

--- a/internal/array.go
+++ b/internal/array.go
@@ -255,7 +255,7 @@ func (t *sizedArrayType) New(arg dgo.Value) dgo.Value {
 	return newArray(t, arg)
 }
 
-func (t *sizedArrayType) Resolve(ap dgo.AliasMap) {
+func (t *sizedArrayType) Resolve(ap dgo.AliasAdder) {
 	te := t.elementType
 	t.elementType = DefaultAnyType
 	t.elementType = ap.Replace(te).(dgo.Type)
@@ -329,7 +329,7 @@ func (t *exactArrayType) ReflectType() reflect.Type {
 	return reflect.SliceOf(t.ElementType().ReflectType())
 }
 
-func (t *exactArrayType) Resolve(ap dgo.AliasMap) {
+func (t *exactArrayType) Resolve(ap dgo.AliasAdder) {
 	t.value.Resolve(ap)
 }
 
@@ -637,7 +637,7 @@ func (t *tupleType) ReflectType() reflect.Type {
 	return reflect.SliceOf(t.ElementType().ReflectType())
 }
 
-func (t *tupleType) Resolve(ap dgo.AliasMap) {
+func (t *tupleType) Resolve(ap dgo.AliasAdder) {
 	s := t.types
 	t.types = nil
 	resolveSlice(s, ap)
@@ -1330,7 +1330,7 @@ func (v *array) RemoveValue(value interface{}) bool {
 	return v.removePos(v.IndexOf(value)) != nil
 }
 
-func (v *array) Resolve(ap dgo.AliasMap) {
+func (v *array) Resolve(ap dgo.AliasAdder) {
 	a := v.slice
 	for i := range a {
 		a[i] = ap.Replace(a[i])
@@ -1598,7 +1598,7 @@ func frozenArray(f string) error {
 	return fmt.Errorf(`%s called on a frozen Array`, f)
 }
 
-func resolveSlice(ts []dgo.Value, ap dgo.AliasMap) {
+func resolveSlice(ts []dgo.Value, ap dgo.AliasAdder) {
 	for i := range ts {
 		ts[i] = ap.Replace(ts[i])
 	}

--- a/internal/array_test.go
+++ b/internal/array_test.go
@@ -338,12 +338,14 @@ func TestTupleType(t *testing.T) {
 }
 
 func TestTupleType_selfReference(t *testing.T) {
+	internal.ResetDefaultAliases()
 	tp := tf.ParseType(`x={string,x}`).(dgo.ArrayType)
 	d := vf.MutableValues()
 	d.Add(`hello`)
 	d.Add(d)
 	require.Instance(t, tp, d)
 
+	internal.ResetDefaultAliases()
 	t2 := tf.ParseType(`x={string,{string,x}}`)
 	require.Assignable(t, tp, t2)
 
@@ -503,11 +505,13 @@ func TestArray_SetType(t *testing.T) {
 }
 
 func TestArray_selfReference(t *testing.T) {
+	internal.ResetDefaultAliases()
 	tp := tf.ParseType(`x=[](string|x)`).(dgo.ArrayType)
 	d := vf.MutableValues(tp, `hello`)
 	d.Add(d)
 	require.Instance(t, tp, d)
 
+	internal.ResetDefaultAliases()
 	t2 := tf.ParseType(`x=[](string|[](string|x))`)
 	require.Assignable(t, tp, t2)
 }

--- a/internal/map.go
+++ b/internal/map.go
@@ -777,18 +777,9 @@ func (g *hashMap) RemoveAll(keys dgo.Array) {
 	})
 }
 
-func (g *hashMap) Resolve(ap dgo.AliasMap) {
-	needRehash := false
+func (g *hashMap) Resolve(ap dgo.AliasAdder) {
 	for e := g.first; e != nil; e = e.next {
-		if rk := ap.Replace(e.key); rk != e.key {
-			e.key = rk
-			needRehash = true
-		}
 		e.value = ap.Replace(e.value)
-	}
-
-	if needRehash {
-		g.resize(g, 0)
 	}
 }
 
@@ -1163,7 +1154,7 @@ func (t *sizedMapType) ReflectType() reflect.Type {
 	return reflect.MapOf(t.KeyType().ReflectType(), t.ValueType().ReflectType())
 }
 
-func (t *sizedMapType) Resolve(ap dgo.AliasMap) {
+func (t *sizedMapType) Resolve(ap dgo.AliasAdder) {
 	kt := t.keyType
 	vt := t.valueType
 	t.keyType = DefaultAnyType
@@ -1315,7 +1306,7 @@ func (t *exactMapType) ReflectType() reflect.Type {
 	return reflect.MapOf(t.KeyType().ReflectType(), t.ValueType().ReflectType())
 }
 
-func (t *exactMapType) Resolve(ap dgo.AliasMap) {
+func (t *exactMapType) Resolve(ap dgo.AliasAdder) {
 	if ac, ok := t.value.(dgo.AliasContainer); ok {
 		ac.Resolve(ap)
 	}

--- a/internal/mapstruct.go
+++ b/internal/mapstruct.go
@@ -342,7 +342,7 @@ func (t *structType) ReflectType() reflect.Type {
 	return reflect.MapOf(t.KeyType().ReflectType(), t.ValueType().ReflectType())
 }
 
-func (t *structType) Resolve(ap dgo.AliasMap) {
+func (t *structType) Resolve(ap dgo.AliasAdder) {
 	ks := t.keys.slice
 	vs := t.values.slice
 	t.keys.slice = []dgo.Value{}

--- a/internal/meta.go
+++ b/internal/meta.go
@@ -54,7 +54,11 @@ func (t *metaType) Equals(v interface{}) bool {
 }
 
 func (t *metaType) HashCode() int {
-	return int(dgo.TiMeta)*1321 + t.tp.HashCode()
+	h := int(dgo.TiMeta) * 1321
+	if t.tp != nil {
+		h += t.tp.HashCode()
+	}
+	return h
 }
 
 func (t *metaType) Instance(v interface{}) bool {
@@ -106,7 +110,7 @@ func (t *metaType) ReflectType() reflect.Type {
 	return reflectTypeType
 }
 
-func (t *metaType) Resolve(ap dgo.AliasMap) {
+func (t *metaType) Resolve(ap dgo.AliasAdder) {
 	tp := t.tp
 	t.tp = DefaultAnyType
 	t.tp = ap.Replace(tp).(dgo.Type)

--- a/internal/not.go
+++ b/internal/not.go
@@ -87,7 +87,7 @@ func (t *notType) ReflectType() reflect.Type {
 	return reflectAnyType
 }
 
-func (t *notType) Resolve(ap dgo.AliasMap) {
+func (t *notType) Resolve(ap dgo.AliasAdder) {
 	tn := t.negated
 	t.negated = DefaultAnyType
 	t.negated = ap.Replace(tn).(dgo.Type)

--- a/internal/string.go
+++ b/internal/string.go
@@ -365,14 +365,14 @@ func (t *patternType) Assignable(other dgo.Type) bool {
 	case *exactStringType:
 		return t.IsInstance(ot.value.s)
 	case *patternType:
-		return t.String() == ot.String()
+		return t.rxString() == ot.rxString()
 	}
 	return CheckAssignableTo(nil, other, t)
 }
 
 func (t *patternType) Equals(v interface{}) bool {
 	if ov, ok := v.(*patternType); ok {
-		return t.String() == ov.String()
+		return t.rxString() == ov.rxString()
 	}
 	return false
 }
@@ -382,7 +382,7 @@ func (t *patternType) Generic() dgo.Type {
 }
 
 func (t *patternType) HashCode() int {
-	return util.StringHash(t.String())
+	return util.StringHash(t.rxString())
 }
 
 func (t *patternType) Instance(v interface{}) bool {
@@ -413,6 +413,10 @@ func (t *patternType) New(arg dgo.Value) dgo.Value {
 
 func (t *patternType) ReflectType() reflect.Type {
 	return reflectStringType
+}
+
+func (t *patternType) rxString() string {
+	return (t.Regexp).String()
 }
 
 func (t *patternType) Type() dgo.Type {

--- a/internal/ternary.go
+++ b/internal/ternary.go
@@ -125,7 +125,7 @@ func (t *allOfType) ReflectType() reflect.Type {
 	return commonReflectTo(t.slice, typeAsType)
 }
 
-func (t *allOfType) Resolve(ap dgo.AliasMap) {
+func (t *allOfType) Resolve(ap dgo.AliasAdder) {
 	s := t.slice
 	t.slice = nil
 	resolveSlice(s, ap)
@@ -337,7 +337,7 @@ func (t *anyOfType) ReflectType() reflect.Type {
 	return commonReflectTo(t.slice, typeAsType)
 }
 
-func (t *anyOfType) Resolve(ap dgo.AliasMap) {
+func (t *anyOfType) Resolve(ap dgo.AliasAdder) {
 	s := t.slice
 	t.slice = nil
 	resolveSlice(s, ap)
@@ -460,7 +460,7 @@ func (t *oneOfType) ReflectType() reflect.Type {
 	return commonReflectTo(t.slice, typeAsType)
 }
 
-func (t *oneOfType) Resolve(ap dgo.AliasMap) {
+func (t *oneOfType) Resolve(ap dgo.AliasAdder) {
 	s := t.slice
 	t.slice = nil
 	resolveSlice(s, ap)

--- a/internal/type.go
+++ b/internal/type.go
@@ -133,7 +133,7 @@ var Parse func(s string) dgo.Value
 //
 // The alias map is optional. If given, the parser will recognize the type aliases provided in the map
 // and also add any new aliases declared within the parsed content to that map.
-var ParseFile func(am dgo.AliasMap, fileName, content string) dgo.Value
+var ParseFile func(am dgo.AliasAdder, fileName, content string) dgo.Value
 
 // TypeString produces the string that represents the given type
 var TypeString func(dgo.Type) string

--- a/streamer/decoder.go
+++ b/streamer/decoder.go
@@ -12,11 +12,11 @@ import (
 type dataDecoder struct {
 	BasicCollector
 	dialect  Dialect
-	aliasMap dgo.AliasMap
+	aliasMap dgo.AliasAdder
 }
 
-// DataDecoder returns a decoder capable of decoding a stream of rich data representations into the corresponding values
-func DataDecoder(aliasMap dgo.AliasMap, d Dialect) Collector {
+// DataDecoder returns a decoder capable of decoding a stream of rich data representations into the corresponding values.
+func DataDecoder(aliasMap dgo.AliasAdder, d Dialect) Collector {
 	c := &dataDecoder{aliasMap: aliasMap, dialect: d}
 	c.Init()
 	return c

--- a/streamer/decoder_test.go
+++ b/streamer/decoder_test.go
@@ -68,8 +68,9 @@ func TestDataDecoder_selfref(t *testing.T) {
 }
 
 func TestDataDecoder_alias(t *testing.T) {
-	aliasMap := tf.NewAliasMap()
-	tf.ParseFile(aliasMap, ``, `ne=string[1]`)
+	aliasMap := tf.BuiltInAliases().Collect(func(aa dgo.AliasAdder) {
+		tf.ParseFile(aa, ``, `ne=string[1]`)
+	})
 	a := vf.Values(tf.String(1))
 
 	// Transform rich data to plain data
@@ -77,9 +78,9 @@ func TestDataDecoder_alias(t *testing.T) {
 	streamer.New(aliasMap, nil).Stream(a, c)
 
 	// Transform back to plain data
-	aliasMap = tf.NewAliasMap()
-	d := streamer.DataDecoder(aliasMap, nil)
-	streamer.New(nil, nil).Stream(c.Value(), d)
-
+	aliasMap = tf.BuiltInAliases().Collect(func(aa dgo.AliasAdder) {
+		d := streamer.DataDecoder(aa, nil)
+		streamer.New(nil, nil).Stream(c.Value(), d)
+	})
 	require.Equal(t, `ne`, aliasMap.GetName(tf.String(1)))
 }

--- a/streamer/dialect.go
+++ b/streamer/dialect.go
@@ -35,7 +35,7 @@ type Dialect interface {
 	TimeTypeName() dgo.String
 
 	// ParseType parses the given type string and returns the resulting Type. The default parser will parse dgo syntax
-	ParseType(aliasMap dgo.AliasMap, typeString dgo.String) dgo.Type
+	ParseType(aliasMap dgo.AliasAdder, typeString dgo.String) dgo.Type
 }
 
 // DgoDialect returns the default dialect which is dgo
@@ -88,6 +88,6 @@ func (d dgoDialect) TimeTypeName() dgo.String {
 	return timeType
 }
 
-func (d dgoDialect) ParseType(aliasMap dgo.AliasMap, typeString dgo.String) dgo.Type {
+func (d dgoDialect) ParseType(aliasMap dgo.AliasAdder, typeString dgo.String) dgo.Type {
 	return typ.AsType(tf.ParseFile(aliasMap, ``, typeString.GoString()))
 }

--- a/streamer/pcore/pcoredialect.go
+++ b/streamer/pcore/pcoredialect.go
@@ -57,6 +57,6 @@ func (d pcoreDialect) TimeTypeName() dgo.String {
 	return timeType
 }
 
-func (d pcoreDialect) ParseType(aliasMap dgo.AliasMap, typeString dgo.String) (dt dgo.Type) {
+func (d pcoreDialect) ParseType(aliasMap dgo.AliasAdder, typeString dgo.String) (dt dgo.Type) {
 	return typ.AsType(Parse(typeString.GoString()))
 }

--- a/streamer/streamer_test.go
+++ b/streamer/streamer_test.go
@@ -73,8 +73,10 @@ func TestEncode_time(t *testing.T) {
 }
 
 func TestEncode_alias(t *testing.T) {
-	am := tf.NewAliasMap()
-	tp := tf.ParseFile(am, ``, `ne=string[1]`)
+	var tp dgo.Value
+	am := tf.BuiltInAliases().Collect(func(aa dgo.AliasAdder) {
+		tp = tf.ParseFile(aa, ``, `ne=string[1]`)
+	})
 	c := streamer.NewCollector()
 	streamer.New(am, nil).Stream(tp, c)
 	require.Equal(t, vf.Map(`__type`, `alias`, `__value`, vf.Strings(`ne`, `string[1]`)), c.Value())

--- a/tf/type.go
+++ b/tf/type.go
@@ -30,13 +30,24 @@ func Parse(content string) dgo.Value {
 //
 // The alias map is optional. If given, the parser will recognize the type aliases provided in the map
 // and also add any new aliases declared within the parsed content to that map.
-func ParseFile(aliasMap dgo.AliasMap, fileName, content string) dgo.Value {
+func ParseFile(aliasMap dgo.AliasAdder, fileName, content string) dgo.Value {
 	return parser.ParseFile(aliasMap, fileName, content)
 }
 
-// NewAliasMap creates a new dgo.Alias map to be used as a scope when parsing types
-func NewAliasMap() dgo.AliasMap {
-	return internal.NewAliasMap()
+// AddDefaultAliases adds the new aliases to the default alias map by passing an AliasAdder to the function
+// The function is safe from a concurrency perspective.
+func AddDefaultAliases(adderFunc func(aliasAdder dgo.AliasAdder)) {
+	internal.AddDefaultAliases(adderFunc)
+}
+
+// BuiltInAliases returns the frozen built-in dgo.AliasMap
+func BuiltInAliases() dgo.AliasMap {
+	return internal.BuiltInAliases()
+}
+
+// DefaultAliases returns the default dgo.AliasMap
+func DefaultAliases() dgo.AliasMap {
+	return internal.DefaultAliases()
 }
 
 // Meta creates the meta type for the given type

--- a/tf/type.go
+++ b/tf/type.go
@@ -2,6 +2,7 @@ package tf
 
 import (
 	"reflect"
+	"sync"
 
 	"github.com/lyraproj/dgo/dgo"
 	"github.com/lyraproj/dgo/internal"
@@ -38,6 +39,15 @@ func ParseFile(aliasMap dgo.AliasAdder, fileName, content string) dgo.Value {
 // The function is safe from a concurrency perspective.
 func AddDefaultAliases(adderFunc func(aliasAdder dgo.AliasAdder)) {
 	internal.AddDefaultAliases(adderFunc)
+}
+
+// AddAliases will call the given adder function, and if entries were added, lock the appointed Locker, create
+// a copy of the appointed AliasMap, add the entries to that copy, swap the appointed AliasMap for the copy,
+// and finally release the lock.
+//
+// No Locker is locked and no swap will take place if the adder function doesn't add anything.
+func AddAliases(mapToReplace *dgo.AliasMap, lock sync.Locker, adder func(adder dgo.AliasAdder)) {
+	internal.AddAliases(mapToReplace, lock, adder)
 }
 
 // BuiltInAliases returns the frozen built-in dgo.AliasMap


### PR DESCRIPTION
The stringer.TypeString method currently expands all types as much as
possible and will emit the string "<recursive self reference to ...>"
whenever it encounters a self referencing alias.

This commit changes the TypeString method so that it instead uses the
`AliasMap` obtained from the function `DefaultAliases` to resolve types
into their respective alias names, thereby enabling types like `data`
to be printed as "data" rather than with the aforementioned recursive
message.

Since DefaultAliases is also used as the default AliasMap when parsing
or deserializing, the aliases added when doing that will be recognized
by the TypePrinter.