### PR TITLE
Remove ability to have a type embedded in Map and Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,8 @@ to `string`, `string[5]`, `string[0,10]`, `"hello"|"goodbye"`, but it is not ass
 instance of that other type.
 
 #### Collection types
-The default type for an Array or a Map can be overridden. This is particularly useful when working with
-mutable collections. If an explicit type is given to the collection, it will instead ensure that any modifications
-made to it will be in conformance with that type. The default type is backed by the collection and changes
-dynamically when the collection is modified.
+The type of a collection is just a cast of the collection itself and hence, will change dynamically when the collection
+is modified.
 
 ## Immutability
 

--- a/dgo/array.go
+++ b/dgo/array.go
@@ -118,10 +118,6 @@ type (
 		// given mapper function.
 		Map(mapper Mapper) Array
 
-		// MapTo is like Map but with the added ability to constrain the created Array with a given
-		// ArrayType.
-		MapTo(t ArrayType, mapper Mapper) Array
-
 		// One returns true if the predicate returns true for exactly one value of this Array.
 		One(predicate Predicate) bool
 
@@ -159,10 +155,6 @@ type (
 		// Set replaces the given value at the given position and returns the old value for the position.
 		// The method panics if the receiver is frozen
 		Set(pos int, val interface{}) Value
-
-		// SetType sets the type for this Array to the given argument which must be an ArrayType or a string that evaluates
-		// to an ArrayType. The Array must be mutable and an instance of the given type
-		SetType(t interface{})
 
 		// Slice returns a slice of this array, starting at position start and ending at position end-1
 		Slice(start, end int) Array

--- a/dgo/map.go
+++ b/dgo/map.go
@@ -114,10 +114,6 @@ type (
 		// panic if the map is immutable.
 		RemoveAll(keys Array)
 
-		// SetType sets the type for this Map to the given argument which must be a MapType or a string that evaluates
-		// to a MapType. The Map must be mutable and an instance of the given type
-		SetType(t interface{})
-
 		// StringKeys returns true if this map's key type is assignable to String (i.e. if all keys are strings)
 		StringKeys() bool
 

--- a/dgo_test/require.go
+++ b/dgo_test/require.go
@@ -175,7 +175,7 @@ func NotNil(t *testing.T, v interface{}) {
 }
 
 // Panic will fail unless a call to f results in a panic and the recovered value matches v
-func Panic(t *testing.T, f func(), v interface{}) {
+func Panic(t *testing.T, f func(), v string) {
 	t.Helper()
 	var err error
 
@@ -197,15 +197,8 @@ func Panic(t *testing.T, f func(), v interface{}) {
 		return
 	}
 
-	switch v := v.(type) {
-	case string:
-		if regexp.MustCompile(v).MatchString(err.Error()) {
-			return
-		}
-	case dgo.Value:
-		if v.Equals(err) {
-			return
-		}
+	if regexp.MustCompile(v).MatchString(err.Error()) {
+		return
 	}
-	t.Errorf(`recovered "%s" does not match "%v"`, err.Error(), v)
+	t.Errorf(`recovered "%s" does not match "%s"`, err.Error(), v)
 }

--- a/internal/array.go
+++ b/internal/array.go
@@ -14,7 +14,6 @@ import (
 type (
 	array struct {
 		slice  []dgo.Value
-		typ    dgo.ArrayType
 		frozen bool
 	}
 
@@ -755,37 +754,9 @@ func ArrayFromReflected(vr reflect.Value, frozen bool) dgo.Value {
 	return &array{slice: arr, frozen: frozen}
 }
 
-func asArrayType(typ interface{}) dgo.ArrayType {
-	if typ == nil {
-		return nil
-	}
-
-	parseArrayType := func(s string) dgo.ArrayType {
-		if t, ok := Parse(s).(dgo.ArrayType); ok {
-			return t
-		}
-		panic(fmt.Errorf("expression '%s' does not evaluate to an array type", s))
-	}
-
-	var mt dgo.ArrayType
-	switch typ := typ.(type) {
-	case dgo.ArrayType:
-		mt = typ
-	case string:
-		mt = parseArrayType(typ)
-	case dgo.String:
-		mt = parseArrayType(typ.GoString())
-	default:
-		mt = TypeFromReflected(reflect.TypeOf(typ)).(dgo.ArrayType)
-	}
-	return mt
-}
-
-// ArrayWithCapacity creates a new mutable array of the given type and initial capacity. The type can be nil, the
-// zero value of a go slice, a dgo.ArrayType, or a dgo string that parses to a dgo.ArrayType.
-func ArrayWithCapacity(capacity int, typ interface{}) dgo.Array {
-	mt := asArrayType(typ)
-	return &array{slice: make([]dgo.Value, 0, capacity), typ: mt, frozen: false}
+// ArrayWithCapacity creates a new mutable array of the given type and initial capacity.
+func ArrayWithCapacity(capacity int) dgo.Array {
+	return &array{slice: make([]dgo.Value, 0, capacity), frozen: false}
 }
 
 // WrapSlice wraps the given slice in an array. Unset entries in the slice will be replaced by Nil.
@@ -856,69 +827,17 @@ func Values(values []interface{}) dgo.Array {
 	return &array{slice: valueSlice(values, true), frozen: true}
 }
 
-func (v *array) assertType(e dgo.Value, pos int) {
-	if t := v.typ; t != nil {
-		sz := len(v.slice)
-		if pos >= sz {
-			sz++
-			if sz > t.Max() {
-				panic(IllegalSize(t, sz))
-			}
-		}
-		var et dgo.Type
-		if tp, ok := t.(dgo.TupleType); ok {
-			if tp.Variadic() {
-				lp := tp.Len() - 1
-				if pos < lp {
-					et = tp.Element(pos)
-				} else {
-					et = tp.Element(lp)
-				}
-			} else {
-				et = tp.Element(pos)
-			}
-		} else {
-			et = t.ElementType()
-		}
-		if !et.Instance(e) {
-			panic(IllegalAssignment(et, e))
-		}
-	}
-}
-
-func (v *array) assertTypes(values dgo.Iterable) {
-	if t := v.typ; t != nil {
-		addedSize := values.Len()
-		if addedSize == 0 {
-			return
-		}
-		sz := len(v.slice)
-		if sz+addedSize > t.Max() {
-			panic(IllegalSize(t, sz+addedSize))
-		}
-		et := t.ElementType()
-		values.Each(func(e dgo.Value) {
-			if !et.Instance(e) {
-				panic(IllegalAssignment(et, e))
-			}
-		})
-	}
-}
-
 func (v *array) Add(vi interface{}) {
 	if v.frozen {
 		panic(frozenArray(`Add`))
 	}
-	val := Value(vi)
-	v.assertType(val, len(v.slice))
-	v.slice = append(v.slice, val)
+	v.slice = append(v.slice, Value(vi))
 }
 
 func (v *array) AddAll(values dgo.Iterable) {
 	if v.frozen {
 		panic(frozenArray(`AddAll`))
 	}
-	v.assertTypes(values)
 	a := v.slice
 	if ar, ok := values.(*array); ok {
 		a = ar.AppendToSlice(a)
@@ -932,9 +851,7 @@ func (v *array) AddValues(values ...interface{}) {
 	if v.frozen {
 		panic(frozenArray(`AddValues`))
 	}
-	va := valueSlice(values, false)
-	v.assertTypes(&array{slice: va})
-	v.slice = append(v.slice, va...)
+	v.slice = append(v.slice, valueSlice(values, false)...)
 }
 
 func (v *array) All(predicate dgo.Predicate) bool {
@@ -1027,7 +944,7 @@ func (v *array) Copy(frozen bool) dgo.Array {
 			}
 		}
 	}
-	return &array{slice: cp, typ: v.typ, frozen: frozen}
+	return &array{slice: cp, frozen: frozen}
 }
 
 func (v *array) ContainsAll(other dgo.Iterable) bool {
@@ -1192,9 +1109,7 @@ func (v *array) Insert(pos int, vi interface{}) {
 	if v.frozen {
 		panic(frozenArray(`Insert`))
 	}
-	val := Value(vi)
-	v.assertType(val, pos)
-	v.slice = append(v.slice[:pos], append([]dgo.Value{val}, v.slice[pos:]...)...)
+	v.slice = append(v.slice[:pos], append([]dgo.Value{Value(vi)}, v.slice[pos:]...)...)
 }
 
 // InterfaceSlice returns the values held by the Array as a slice. The slice will
@@ -1210,31 +1125,6 @@ func (v *array) InterfaceSlice() []interface{} {
 
 func (v *array) Len() int {
 	return len(v.slice)
-}
-
-func (v *array) MapTo(t dgo.ArrayType, mapper dgo.Mapper) dgo.Array {
-	if t == nil {
-		return v.Map(mapper)
-	}
-	a := v.slice
-	l := len(a)
-	if l < t.Min() {
-		panic(IllegalSize(t, l))
-	}
-	if l > t.Max() {
-		panic(IllegalSize(t, l))
-	}
-	et := t.ElementType()
-	vs := make([]dgo.Value, len(a))
-
-	for i := range a {
-		mv := Value(mapper(a[i]))
-		if !et.Instance(mv) {
-			panic(IllegalAssignment(et, mv))
-		}
-		vs[i] = mv
-	}
-	return &array{slice: vs, typ: t, frozen: v.frozen}
 }
 
 func (v *array) Map(mapper dgo.Mapper) dgo.Array {
@@ -1302,11 +1192,6 @@ func (v *array) removePos(pos int) dgo.Value {
 	a := v.slice
 	if pos >= 0 && pos < len(a) {
 		newLen := len(a) - 1
-		if v.typ != nil {
-			if v.typ.Min() > newLen {
-				panic(IllegalSize(v.typ, newLen))
-			}
-		}
 		val := a[pos]
 		copy(a[pos:], a[pos+1:])
 		a[newLen] = nil // release to GC
@@ -1346,7 +1231,7 @@ func (v *array) Reject(predicate dgo.Predicate) dgo.Array {
 			vs = append(vs, e)
 		}
 	}
-	return &array{slice: vs, typ: v.typ, frozen: v.frozen}
+	return &array{slice: vs, frozen: v.frozen}
 }
 
 func (v *array) SameValues(other dgo.Iterable) bool {
@@ -1362,30 +1247,16 @@ func (v *array) Select(predicate dgo.Predicate) dgo.Array {
 			vs = append(vs, e)
 		}
 	}
-	return &array{slice: vs, typ: v.typ, frozen: v.frozen}
+	return &array{slice: vs, frozen: v.frozen}
 }
 
 func (v *array) Set(pos int, vi interface{}) dgo.Value {
 	if v.frozen {
 		panic(frozenArray(`Set`))
 	}
-	val := Value(vi)
-	v.assertType(val, pos)
 	old := v.slice[pos]
-	v.slice[pos] = val
+	v.slice[pos] = Value(vi)
 	return old
-}
-
-func (v *array) SetType(ti interface{}) {
-	if v.frozen {
-		panic(frozenArray(`SetType`))
-	}
-	mt := asArrayType(ti)
-	if mt == nil || mt.Instance(v) {
-		v.typ = mt
-		return
-	}
-	panic(IllegalAssignment(mt, v))
 }
 
 func (v *array) Slice(i, j int) dgo.Array {
@@ -1417,7 +1288,7 @@ func (v *array) Sort() dgo.Array {
 		}
 		return a.Type().TypeIdentifier() < b.Type().TypeIdentifier()
 	})
-	return &array{slice: sorted, typ: v.typ, frozen: v.frozen}
+	return &array{slice: sorted, frozen: v.frozen}
 }
 
 func (v *array) String() string {
@@ -1495,12 +1366,9 @@ func (v *array) ToMapFromEntries() (dgo.Map, bool) {
 }
 
 func (v *array) Type() dgo.Type {
-	if v.typ == nil {
-		ea := &exactArrayType{value: v}
-		ea.ExactType = ea
-		return ea
-	}
-	return v.typ
+	ea := &exactArrayType{value: v}
+	ea.ExactType = ea
+	return ea
 }
 
 func (v *array) Unique() dgo.Array {
@@ -1530,7 +1398,7 @@ nextVal:
 	if ui == top {
 		return v
 	}
-	return &array{slice: u[:ui], typ: v.typ, frozen: v.frozen}
+	return &array{slice: u[:ui], frozen: v.frozen}
 }
 
 func (v *array) Pop() (dgo.Value, bool) {
@@ -1545,9 +1413,7 @@ func (v *array) Pop() (dgo.Value, bool) {
 }
 
 func (v *array) With(vi interface{}) dgo.Array {
-	val := Value(vi)
-	v.assertType(val, len(v.slice))
-	return &array{slice: append(v.slice, val), typ: v.typ, frozen: v.frozen}
+	return &array{slice: append(v.slice, Value(vi)), frozen: v.frozen}
 }
 
 func (v *array) WithAll(values dgo.Iterable) dgo.Array {
@@ -1567,9 +1433,7 @@ func (v *array) WithValues(values ...interface{}) dgo.Array {
 	if len(values) == 0 {
 		return v
 	}
-	va := valueSlice(values, v.frozen)
-	v.assertTypes(&array{slice: va})
-	return &array{slice: append(v.slice, va...), typ: v.typ, frozen: v.frozen}
+	return &array{slice: append(v.slice, valueSlice(values, v.frozen)...), frozen: v.frozen}
 }
 
 // ReplaceNil performs an in-place replacement of nil interfaces with the NilValue

--- a/internal/hashmap_test.go
+++ b/internal/hashmap_test.go
@@ -40,7 +40,7 @@ func BenchmarkHashMapStrings(b *testing.B) {
 	sz := b.N + lookupsPerOp
 	ks := buildStringKeys(sz)
 	k := make([]dgo.Value, sz)
-	m := MapWithCapacity(sz, nil)
+	m := MapWithCapacity(sz)
 	for i := 0; i < sz; i++ {
 		key := makeHString(ks[i])
 		m.Put(key, intVal(i))
@@ -61,7 +61,7 @@ func BenchmarkHashMapStringsNoHashCache(b *testing.B) {
 	sz := b.N + lookupsPerOp
 	ks := buildStringKeys(sz)
 	k := make([]*hstring, sz)
-	m := MapWithCapacity(sz, nil)
+	m := MapWithCapacity(sz)
 	for i := 0; i < sz; i++ {
 		key := makeHString(ks[i])
 		m.Put(key, intVal(i))
@@ -81,7 +81,7 @@ func BenchmarkHashMapStringsNoHashCache(b *testing.B) {
 func BenchmarkHashMapIntegers(b *testing.B) {
 	sz := b.N + lookupsPerOp
 	k := make([]dgo.Value, sz)
-	m := MapWithCapacity(sz, nil)
+	m := MapWithCapacity(sz)
 	for i := 0; i < sz; i++ {
 		key := intVal(rand.Intn(sz * rndFactor))
 		m.Put(key, intVal(i))

--- a/internal/map.go
+++ b/internal/map.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"errors"
 	"fmt"
 	"math"
 	"reflect"
@@ -12,7 +11,7 @@ import (
 	"github.com/lyraproj/dgo/dgo"
 )
 
-const initialCapacity = 1 << 4
+const initialCapacity = 1 << 3
 const maximumCapacity = 1 << 30
 const loadFactor = 0.75
 
@@ -54,7 +53,6 @@ type (
 	// hashMap is an unsorted Map that uses a hash table
 	hashMap struct {
 		table  []*hashNode
-		typ    dgo.MapType
 		len    int
 		first  *hashNode
 		last   *hashNode
@@ -216,7 +214,7 @@ func mapFromArgs(args []interface{}, frozen bool) dgo.Map {
 		if frozen {
 			return emptyMap
 		}
-		return MapWithCapacity(0, nil)
+		return MapWithCapacity(0)
 	case l == 1:
 		a0 := args[0]
 		if ar, ok := a0.(dgo.Array); ok && ar.Len()%2 == 0 {
@@ -300,11 +298,6 @@ func FromReflectedMap(rm reflect.Value, frozen bool) dgo.Value {
 		m.last = hn
 		tbl[hk] = hn
 	}
-	var typ dgo.MapType
-	if !frozen {
-		typ = TypeFromReflected(rm.Type()).(dgo.MapType)
-	}
-	m.typ = typ
 	return m
 }
 
@@ -314,34 +307,13 @@ func FromReflectedStruct(rv reflect.Value) dgo.Struct {
 	return &structVal{rs: rv, frozen: false}
 }
 
-// MapWithCapacity creates an empty dgo.Map suitable to hold a given number of entries. The map can be optionally
-// constrained by the given type which can be nil, the zero value of a go map, or a dgo.MapType
-func MapWithCapacity(capacity int, typ interface{}) dgo.Map {
+// MapWithCapacity creates an empty dgo.Map suitable to hold a given number of entries.
+func MapWithCapacity(capacity int) dgo.Map {
 	if capacity <= 0 {
 		capacity = initialCapacity
 	}
 	capacity = int(float64(capacity) / loadFactor)
-	return &hashMap{table: make([]*hashNode, tableSizeFor(capacity)), len: 0, typ: asMapType(typ), frozen: false}
-}
-
-func asMapType(ti interface{}) (mt dgo.MapType) {
-	ok := false
-	switch ti := ti.(type) {
-	case dgo.Type:
-		mt, ok = ti.(dgo.MapType)
-	case dgo.String:
-		mt, ok = Parse(ti.GoString()).(dgo.MapType)
-	case string:
-		mt, ok = Parse(ti).(dgo.MapType)
-	case nil:
-		ok = true
-	default:
-		mt, ok = TypeFromReflected(reflect.TypeOf(ti)).(dgo.MapType)
-	}
-	if !ok {
-		panic(errors.New(`Map.SetType: argument does not evaluate to a map type`))
-	}
-	return
+	return &hashMap{table: make([]*hashNode, tableSizeFor(capacity)), len: 0, frozen: false}
 }
 
 func (g *hashMap) All(predicate dgo.EntryPredicate) bool {
@@ -587,7 +559,7 @@ func (g *hashMap) Merge(associations dgo.Map) dgo.Map {
 	if l == 0 {
 		return associations
 	}
-	c := &hashMap{len: l, typ: g.typ}
+	c := &hashMap{len: l}
 	g.resize(c, l+associations.Len())
 	c.PutAll(associations)
 	c.frozen = g.frozen
@@ -611,14 +583,12 @@ func (g *hashMap) Put(ki, vi interface{}) dgo.Value {
 	hk = (len(tbl) - 1) & hs
 	for e := tbl[hk]; e != nil; e = e.hashNext {
 		if k.Equals(e.key) {
-			g.assertType(k, v, 0)
 			old := e.value
 			e.value = v
 			return old
 		}
 	}
 
-	g.assertType(k, v, 1)
 	if float64(g.len+1) > float64(len(g.table))*loadFactor {
 		g.resize(g, 1)
 		tbl = g.table
@@ -658,12 +628,10 @@ func (g *hashMap) PutAll(associations dgo.Map) {
 		hk := (len(tbl) - 1) & hash(key.HashCode())
 		for e := tbl[hk]; e != nil; e = e.hashNext {
 			if key.Equals(e.key) {
-				g.assertType(key, val, 0)
 				e.value = val
 				return
 			}
 		}
-		g.assertType(key, val, 1)
 		nd := &hashNode{mapEntry: mapEntry{key: frozenCopy(key), value: val}, hashNext: tbl[hk], prev: g.last}
 		if g.first == nil {
 			g.first = nd
@@ -783,26 +751,11 @@ func (g *hashMap) Resolve(ap dgo.AliasAdder) {
 	}
 }
 
-func (g *hashMap) SetType(ti interface{}) {
-	if g.frozen {
-		panic(frozenMap(`SetType`))
-	}
-	mt := asMapType(ti)
-	if mt == nil || mt.Instance(g) {
-		g.typ = mt
-		return
-	}
-	panic(IllegalAssignment(mt, g))
-}
-
 func (g *hashMap) String() string {
 	return util.ToStringERP(g)
 }
 
 func (g *hashMap) StringKeys() bool {
-	if g.typ != nil {
-		return DefaultStringType.Assignable(g.typ.KeyType())
-	}
 	for e := g.first; e != nil; e = e.next {
 		if _, str := e.key.(*hstring); !str {
 			return false
@@ -816,12 +769,12 @@ func (g *hashMap) With(ki, vi interface{}) dgo.Map {
 	key := Value(ki)
 	val := Value(vi)
 	if g.table == nil {
-		c = &hashMap{table: make([]*hashNode, tableSizeFor(initialCapacity)), len: g.len, typ: g.typ}
+		c = &hashMap{table: make([]*hashNode, tableSizeFor(initialCapacity)), len: g.len}
 	} else {
 		if val.Equals(g.Get(key)) {
 			return g
 		}
-		c = &hashMap{len: g.len, typ: g.typ}
+		c = &hashMap{len: g.len}
 		g.resize(c, 1)
 	}
 	c.Put(key, val)
@@ -834,7 +787,7 @@ func (g *hashMap) Without(ki interface{}) dgo.Map {
 	if g.Get(key) == nil {
 		return g
 	}
-	c := &hashMap{typ: g.typ, len: g.len}
+	c := &hashMap{len: g.len}
 	g.resize(c, 0)
 	c.Remove(key)
 	c.frozen = g.frozen
@@ -845,7 +798,7 @@ func (g *hashMap) WithoutAll(keys dgo.Array) dgo.Map {
 	if g.len == 0 || keys.Len() == 0 {
 		return g
 	}
-	c := &hashMap{typ: g.typ, len: g.len}
+	c := &hashMap{len: g.len}
 	g.resize(c, 0)
 	c.RemoveAll(keys)
 	if g.len == c.len {
@@ -856,41 +809,13 @@ func (g *hashMap) WithoutAll(keys dgo.Array) dgo.Map {
 }
 
 func (g *hashMap) Type() dgo.Type {
-	if g.typ == nil {
-		et := &exactMapType{value: g}
-		et.ExactType = et
-		return et
-	}
-	return g.typ
+	et := &exactMapType{value: g}
+	et.ExactType = et
+	return et
 }
 
 func (g *hashMap) Values() dgo.Array {
 	return &array{slice: g.values(), frozen: g.frozen}
-}
-
-func (g *hashMap) assertType(k, v dgo.Value, addedSize int) {
-	if t := g.typ; t != nil {
-		if st, ok := t.(*structType); ok {
-			if err := st.CheckEntry(k, v); err != nil {
-				panic(err)
-			}
-		} else {
-			kt := t.KeyType()
-			if !kt.Instance(k) {
-				panic(IllegalAssignment(kt, k))
-			}
-			vt := t.ValueType()
-			if !vt.Instance(v) {
-				panic(IllegalAssignment(vt, v))
-			}
-		}
-		if addedSize > 0 {
-			sz := g.len + addedSize
-			if sz > t.Max() {
-				panic(IllegalSize(t, sz))
-			}
-		}
-	}
 }
 
 func (g *hashMap) values() []dgo.Value {
@@ -1260,9 +1185,14 @@ func (t *exactMapType) Each(actor func(dgo.StructMapEntry)) {
 }
 
 func (t *exactMapType) Generic() dgo.Type {
+	kt := Generic(t.KeyType())
+	vt := Generic(t.ValueType())
+	if kt == DefaultAnyType && vt == DefaultAnyType {
+		return DefaultMapType
+	}
 	return &sizedMapType{
-		keyType:   Generic(t.KeyType()),
-		valueType: Generic(t.ValueType()),
+		keyType:   kt,
+		valueType: vt,
 		min:       0,
 		max:       math.MaxInt64}
 }

--- a/internal/mapstruct.go
+++ b/internal/mapstruct.go
@@ -58,7 +58,7 @@ func StructMapTypeUnresolved(additional bool, entries []dgo.StructMapEntry) dgo.
 
 func createExactMap(keys, values []dgo.Value) dgo.StructMapType {
 	l := len(keys)
-	m := MapWithCapacity(l, nil)
+	m := MapWithCapacity(l)
 	for i := 0; i < l; i++ {
 		m.Put(keys[i].(dgo.ExactType).ExactValue(), values[i].(dgo.ExactType).ExactValue())
 	}
@@ -159,24 +159,6 @@ func (t *structType) checkExactKeys() {
 
 func (t *structType) Additional() bool {
 	return t.additional
-}
-
-func (t *structType) CheckEntry(k, v dgo.Value) dgo.Value {
-	ks := t.keys.slice
-	for i := range ks {
-		kt := ks[i].(dgo.Type)
-		if kt.Instance(k) {
-			vt := t.values.slice[i].(dgo.Type)
-			if vt.Instance(v) {
-				return nil
-			}
-			return IllegalAssignment(vt, v)
-		}
-	}
-	if t.additional {
-		return nil
-	}
-	return IllegalMapKey(t, k)
 }
 
 func (t *structType) Assignable(other dgo.Type) bool {

--- a/internal/mapstruct_test.go
+++ b/internal/mapstruct_test.go
@@ -17,16 +17,14 @@ import (
 	"github.com/lyraproj/dgo/vf"
 )
 
-func ExampleMap_SetType_structType() {
+func ExampleMap_structType() {
 	m := vf.Map(`host`, `example.com`, `port`, 22).Copy(false)
-	m.SetType(`{host: string, port: int}`)
 	fmt.Println(m)
 	// Output: {"host":"example.com","port":22}
 }
 
 func ExampleMap_Put_structType() {
 	m := vf.Map(`host`, `example.com`, `port`, 22).Copy(false)
-	m.SetType(`{host: string, port: int}`)
 	m.Put(`port`, 465)
 	fmt.Println(m)
 	// Output: {"host":"example.com","port":465}
@@ -34,28 +32,33 @@ func ExampleMap_Put_structType() {
 
 func ExampleMap_Put_structTypeAdditionalKey() {
 	m := vf.Map(`host`, `example.com`, `port`, 22).Copy(false)
-	m.SetType(`{host: string, port: int, ...}`)
 	m.Put(`login`, `bob`)
 	fmt.Println(m)
 	// Output: {"host":"example.com","port":22,"login":"bob"}
 }
 
 func ExampleMap_Put_structTypeIllegalKey() {
-	m := vf.Map(`host`, `example.com`, `port`, 22).Copy(false)
-	m.SetType(`{host: string, port: int}`)
-	if err := util.Catch(func() { m.Put(`login`, `bob`) }); err != nil {
+	type st struct {
+		Host string
+		Port int
+	}
+	m := vf.Map(&st{Host: `example.com`, Port: 22}).Copy(false)
+	if err := util.Catch(func() { m.Put(`Login`, `bob`) }); err != nil {
 		fmt.Println(err)
 	}
-	// Output: key "login" cannot added to type {"host":string,"port":int}
+	// Output: internal_test.st has no field named 'Login'
 }
 
 func ExampleMap_Put_structTypeIllegalValue() {
-	m := vf.Map(`host`, `example.com`, `port`, 22).Copy(false)
-	m.SetType(`{host: string, port: int}`)
-	if err := util.Catch(func() { m.Put(`port`, `22`) }); err != nil {
+	type st struct {
+		Host string
+		Port int
+	}
+	m := vf.Map(&st{Host: `example.com`, Port: 22}).Copy(false)
+	if err := util.Catch(func() { m.Put(`Port`, `22`) }); err != nil {
 		fmt.Println(err)
 	}
-	// Output: the string "22" cannot be assigned to a variable of type int
+	// Output: reflect: call of reflect.Value.SetString on int Value
 }
 
 func TestStructType_Get(t *testing.T) {

--- a/internal/struct.go
+++ b/internal/struct.go
@@ -273,10 +273,6 @@ func (v *structVal) RemoveAll(keys dgo.Array) {
 	panic(errors.New(`struct fields cannot be removed`))
 }
 
-func (v *structVal) SetType(t interface{}) {
-	panic(errors.New(`struct type is read only`))
-}
-
 func (v *structVal) String() string {
 	return util.ToStringERP(v)
 }
@@ -320,7 +316,7 @@ func (v *structVal) WithoutAll(keys dgo.Array) dgo.Map {
 }
 
 func (v *structVal) toHashMap() *hashMap {
-	c := MapWithCapacity(v.Len(), nil)
+	c := MapWithCapacity(v.Len())
 	v.EachEntry(func(entry dgo.MapEntry) {
 		c.Put(entry.Key(), entry.Value())
 	})

--- a/internal/struct_test.go
+++ b/internal/struct_test.go
@@ -390,16 +390,6 @@ func Test_structMap_Remove(t *testing.T) {
 	require.Panic(t, func() { m.RemoveAll(vf.Values(`A`, `B`)) }, `cannot be removed`)
 }
 
-func Test_structMap_SetType(t *testing.T) {
-	type structA struct {
-		A string
-		B int
-	}
-	s := structA{}
-	m := vf.Map(&s)
-	require.Panic(t, func() { m.SetType(`map[string]int`) }, `type is read only`)
-}
-
 func Test_structMap_String(t *testing.T) {
 	type structA struct {
 		A string

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -98,7 +98,7 @@ func (l *mapLoader) init(im dgo.Map) {
 }
 
 func (l *mapLoader) initMap() dgo.Map {
-	m := vf.MapWithCapacity(5, nil)
+	m := vf.MapWithCapacity(5)
 	m.Put(`name`, l.name)
 	m.Put(`entries`, l.entries)
 	return m
@@ -310,7 +310,7 @@ func (l *childLoader) init(im dgo.Map) {
 }
 
 func (l *childLoader) initMap() dgo.Map {
-	m := vf.MapWithCapacity(2, nil)
+	m := vf.MapWithCapacity(2)
 	m.Put(`loader`, l.Loader)
 	m.Put(`parent`, l.parent)
 	return m

--- a/streamer/basiccollector.go
+++ b/streamer/basiccollector.go
@@ -32,7 +32,7 @@ func (c *BasicCollector) Init() {
 // AddArray initializes and adds a new array and then calls the function with is supposed to
 // add the elements.
 func (c *BasicCollector) AddArray(cap int, doer dgo.Doer) {
-	a := vf.ArrayWithCapacity(nil, cap)
+	a := vf.ArrayWithCapacity(cap)
 	c.Add(a)
 	top := len(c.Stack)
 	c.Stack = append(c.Stack, a)
@@ -43,9 +43,9 @@ func (c *BasicCollector) AddArray(cap int, doer dgo.Doer) {
 // AddMap initializes and adds a new map and then calls the function with is supposed to
 // add an even number of elements as a sequence of key, value, [key, value, ...]
 func (c *BasicCollector) AddMap(cap int, doer dgo.Doer) {
-	h := vf.MutableMap()
+	h := vf.MapWithCapacity(cap)
 	c.Add(h)
-	a := vf.ArrayWithCapacity(nil, cap*2)
+	a := vf.ArrayWithCapacity(cap * 2)
 	top := len(c.Stack)
 	c.Stack = append(c.Stack, a)
 	doer()

--- a/vf/array.go
+++ b/vf/array.go
@@ -11,10 +11,9 @@ func Array(value interface{}) dgo.Array {
 	return internal.Array(value)
 }
 
-// ArrayWithCapacity creates a new mutable array of the given type and initial capacity. The type can be nil, the
-// zero value of a go slice, a dgo.ArrayType, or a dgo string that parses to a dgo.ArrayType.
-func ArrayWithCapacity(typ interface{}, capacity int) dgo.Array {
-	return internal.ArrayWithCapacity(capacity, typ)
+// ArrayWithCapacity creates a new mutable array of the given type and initial capacity.
+func ArrayWithCapacity(capacity int) dgo.Array {
+	return internal.ArrayWithCapacity(capacity)
 }
 
 // WrapSlice wraps the given slice in an array. Unset entries in the slice will be replaced by Nil.

--- a/vf/array_test.go
+++ b/vf/array_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/lyraproj/dgo/dgo"
 	"github.com/lyraproj/dgo/typ"
 
-	"github.com/lyraproj/dgo/util"
 	"github.com/lyraproj/dgo/vf"
 )
 
@@ -22,19 +21,9 @@ func ExampleStrings() {
 
 func ExampleMutableValues() {
 	a := vf.MutableValues()
-	a.SetType(`[]0..0x7f`)
 	a.Add(32)
 	fmt.Println(a)
 	// Output: {32}
-}
-
-func ExampleMutableValues_illegalAssignment() {
-	a := vf.MutableValues()
-	a.SetType(`[]0..0x7f`)
-	if err := util.Catch(func() { a.Add(132) }); err != nil {
-		fmt.Println(err)
-	}
-	// Output: the value 132 cannot be assigned to a variable of type 0..127
 }
 
 func ExampleArguments() {

--- a/vf/map.go
+++ b/vf/map.go
@@ -25,10 +25,9 @@ func MutableMap(m ...interface{}) dgo.Map {
 	return internal.MutableMap(m)
 }
 
-// MapWithCapacity creates an empty dgo.Map suitable to hold a given number of entries. The map can be optionally
-// constrained by the given type which can be nil, the zero value of a go map, or a dgo.MapType
-func MapWithCapacity(capacity int, typ interface{}) dgo.Map {
-	return internal.MapWithCapacity(capacity, typ)
+// MapWithCapacity creates an empty dgo.Map suitable to hold a given number of entries.
+func MapWithCapacity(capacity int) dgo.Map {
+	return internal.MapWithCapacity(capacity)
 }
 
 // FromReflectedMap creates a Map from a reflected map. If frozen is true, the created Map will be

--- a/vf/map_test.go
+++ b/vf/map_test.go
@@ -3,7 +3,6 @@ package vf_test
 import (
 	"fmt"
 
-	"github.com/lyraproj/dgo/util"
 	"github.com/lyraproj/dgo/vf"
 )
 
@@ -22,17 +21,7 @@ func ExampleMap_goMap() {
 
 func ExampleMutableMap() {
 	m := vf.MutableMap()
-	m.SetType(`map[string]0..0x7f`)
 	m.Put(`a`, 32)
 	fmt.Println(m)
 	// Output: {"a":32}
-}
-
-func ExampleMutableMap_illegalAssignment() {
-	m := vf.MutableMap()
-	m.SetType(`map[string]0..0x7f`)
-	if err := util.Catch(func() { m.Put(`c`, 132) }); err != nil {
-		fmt.Println(err)
-	}
-	// Output: the value 132 cannot be assigned to a variable of type 0..127
 }


### PR DESCRIPTION
Prior to this commit, a Map or an Array could have an embedded type
that would override the default type (the type backed by the collection
itself). The reason for this was to allow "typed collections", i.e.
collections that wouldn't accept modifications beyond what its type
would allow.

The approach with typed collections led to ambiguities and overly
complex code. It was also never used in any of dgo's applications since
the most common place to check types when assigning to variables or
passing parameters. The ability to have embedded types in collections
is therefore removed by this commit.