### PR TITLE
Ensure that unfrozen copy is deep

### DIFF
--- a/dgo/array.go
+++ b/dgo/array.go
@@ -25,6 +25,9 @@ type (
 		// FrozenCopy checks if the receiver is frozen. If it is, it returned. If not, a frozen copy
 		// of the receiver is returned.
 		FrozenCopy() Value
+
+		// ThawedCopy returns a thawed copy of the receiver.
+		ThawedCopy() Value
 	}
 
 	// Iterable enables the implementor to express how iteration is performed over contained elements

--- a/internal/alias.go
+++ b/internal/alias.go
@@ -95,6 +95,10 @@ func (a *alias) FrozenCopy() dgo.Value {
 	panic(a.freezeAttempt())
 }
 
+func (a *alias) ThawedCopy() dgo.Value {
+	return a
+}
+
 func (a *alias) freezeAttempt() error {
 	return fmt.Errorf(`attempt to freeze unresolved alias '%s'`, a.Reference())
 }

--- a/internal/array.go
+++ b/internal/array.go
@@ -943,6 +943,12 @@ func (v *array) Copy(frozen bool) dgo.Array {
 				cp[i] = f.FrozenCopy()
 			}
 		}
+	} else {
+		for i := range cp {
+			if f, ok := cp[i].(dgo.Freezable); ok {
+				cp[i] = f.ThawedCopy()
+			}
+		}
 	}
 	return &array{slice: cp, frozen: frozen}
 }
@@ -1068,6 +1074,10 @@ func (v *array) Frozen() bool {
 
 func (v *array) FrozenCopy() dgo.Value {
 	return v.Copy(true)
+}
+
+func (v *array) ThawedCopy() dgo.Value {
+	return v.Copy(false)
 }
 
 func (v *array) GoSlice() []dgo.Value {

--- a/internal/binary.go
+++ b/internal/binary.go
@@ -355,12 +355,11 @@ func (v *binary) Frozen() bool {
 }
 
 func (v *binary) FrozenCopy() dgo.Value {
-	if !v.frozen {
-		cs := make([]byte, len(v.bytes))
-		copy(cs, v.bytes)
-		return &binary{bytes: cs, frozen: true}
-	}
-	return v
+	return v.Copy(true)
+}
+
+func (v *binary) ThawedCopy() dgo.Value {
+	return v.Copy(false)
 }
 
 func (v *binary) GoBytes() []byte {

--- a/internal/binary_test.go
+++ b/internal/binary_test.go
@@ -247,6 +247,10 @@ func TestBinary_Copy(t *testing.T) {
 	c = c.Copy(true)
 	require.True(t, c.Frozen())
 	require.Same(t, c, c.Copy(true))
+
+	c = a.ThawedCopy().(dgo.Binary)
+	require.False(t, c.Frozen())
+	require.NotSame(t, c, c.ThawedCopy())
 }
 
 func TestBinary_Equal(t *testing.T) {

--- a/internal/map_test.go
+++ b/internal/map_test.go
@@ -305,6 +305,16 @@ func TestMap_EntryType(t *testing.T) {
 		vt := v.Type()
 		require.Equal(t, `"a":{1,2}`, vt.String())
 	})
+	m = m.FrozenCopy().(dgo.Map)
+	m.EachEntry(func(v dgo.MapEntry) {
+		require.True(t, v.Frozen())
+		require.NotSame(t, v, v.ThawedCopy())
+	})
+	m = m.ThawedCopy().(dgo.Map)
+	m.EachEntry(func(v dgo.MapEntry) {
+		require.False(t, v.Frozen())
+		require.NotSame(t, v, v.ThawedCopy())
+	})
 }
 
 func TestNewMapType_max_min(t *testing.T) {
@@ -979,6 +989,20 @@ func TestMapEntry_Frozen(t *testing.T) {
 
 	e = internal.NewMapEntry(`a`, vf.MutableValues(`a`))
 	require.NotSame(t, e, e.FrozenCopy())
+}
+
+func TestMapEntry_Thawed(t *testing.T) {
+	e := internal.NewMapEntry(`a`, 1)
+	require.NotSame(t, e, e.ThawedCopy())
+
+	e = e.FrozenCopy().(dgo.MapEntry)
+	require.NotSame(t, e, e.ThawedCopy())
+
+	e = internal.NewMapEntry(`a`, vf.MutableValues(`a`))
+	c := e.ThawedCopy().(dgo.MapEntry)
+	c.Value().(dgo.Array).Set(0, `b`)
+	require.Equal(t, vf.Values(`a`), e.Value())
+	require.Equal(t, vf.Values(`b`), c.Value())
 }
 
 func TestMapEntry_String(t *testing.T) {

--- a/internal/native.go
+++ b/internal/native.go
@@ -105,6 +105,10 @@ func (v *native) FrozenCopy() dgo.Value {
 	panic(fmt.Errorf(`native value cannot be frozen`))
 }
 
+func (v *native) ThawedCopy() dgo.Value {
+	panic(fmt.Errorf(`native value cannot be copied`))
+}
+
 func (v *native) HashCode() int {
 	rv := (*reflect.Value)(v)
 	switch rv.Kind() {

--- a/internal/native_test.go
+++ b/internal/native_test.go
@@ -50,6 +50,7 @@ func TestNative(t *testing.T) {
 	require.False(t, c.Frozen())
 	require.Panic(t, func() { c.Freeze() }, `cannot be frozen`)
 	require.Panic(t, func() { c.FrozenCopy() }, `cannot be frozen`)
+	require.Panic(t, func() { c.ThawedCopy() }, `cannot be copied`)
 
 	require.NotEqual(t, 0, s.HashCode())
 	require.Equal(t, s.HashCode(), s.HashCode())

--- a/internal/sensitive.go
+++ b/internal/sensitive.go
@@ -143,6 +143,13 @@ func (v *sensitive) FrozenCopy() dgo.Value {
 	return v
 }
 
+func (v *sensitive) ThawedCopy() dgo.Value {
+	if f, ok := v.value.(dgo.Freezable); ok {
+		return &sensitive{f.ThawedCopy()}
+	}
+	return v
+}
+
 func (v *sensitive) HashCode() int {
 	return deepHashCode(nil, v)
 }

--- a/internal/sensitive_test.go
+++ b/internal/sensitive_test.go
@@ -84,9 +84,17 @@ func TestSensitive(t *testing.T) {
 	require.Equal(t, s.Unwrap(), c.Unwrap())
 	require.NotSame(t, s.Unwrap(), c.Unwrap())
 
-	s = vf.Sensitive(vf.String(`a`))
+	s = vf.Sensitive(vf.MutableValues(`a`))
+	require.False(t, s.Frozen())
 	c = s.FrozenCopy().(dgo.Sensitive)
+	require.NotSame(t, s, c)
+	require.True(t, c.Frozen())
+	s = c.FrozenCopy().(dgo.Sensitive)
 	require.Same(t, s, c)
+
+	c = s.ThawedCopy().(dgo.Sensitive)
+	require.NotSame(t, s, c)
+	require.False(t, c.Frozen()) // string is frozen regardless
 
 	require.Equal(t, `sensitive [value redacted]`, s.String())
 

--- a/internal/struct.go
+++ b/internal/struct.go
@@ -169,6 +169,21 @@ func (v *structVal) FrozenCopy() dgo.Value {
 	return &structVal{rs: rs, frozen: true}
 }
 
+func (v *structVal) ThawedCopy() dgo.Value {
+	// Perform a by-value copy of the struct
+	rs := reflect.New(v.rs.Type()).Elem() // create and dereference pointer to a zero value
+	rs.Set(v.rs)                          // copy v.rs to the zero value
+
+	for i, n := 0, rs.NumField(); i < n; i++ {
+		ef := rs.Field(i)
+		ev := ValueFromReflected(ef)
+		if f, ok := ev.(dgo.Freezable); ok {
+			ReflectTo(f.ThawedCopy(), ef)
+		}
+	}
+	return &structVal{rs: rs, frozen: false}
+}
+
 func (v *structVal) Find(predicate dgo.EntryPredicate) dgo.MapEntry {
 	rv := v.rs
 	rt := rv.Type()

--- a/internal/struct_test.go
+++ b/internal/struct_test.go
@@ -228,6 +228,28 @@ func Test_structMap_FrozenCopy(t *testing.T) {
 	require.Panic(t, func() { c.Put(`A`, `Adam`) }, `frozen`)
 }
 
+func Test_structMap_ThawedCopy(t *testing.T) {
+	type structA struct {
+		A string
+		E dgo.Array
+	}
+	s := structA{A: `Alpha`}
+	m := vf.Map(&s)
+	m.Put(`E`, vf.MutableValues(`Echo`, `Foxtrot`))
+	m.Freeze()
+
+	c := m.ThawedCopy().(dgo.Map)
+	require.True(t, m.Frozen())
+	require.True(t, m.Get(`E`).(dgo.Freezable).Frozen())
+	require.False(t, c.Frozen())
+	require.False(t, c.Get(`E`).(dgo.Freezable).Frozen())
+
+	c.Put(`A`, `Adam`)
+	require.Equal(t, `Adam`, c.Get(`A`))
+	require.Equal(t, `Alpha`, m.Get(`A`))
+	require.NotSame(t, c, c.FrozenCopy())
+}
+
 func Test_structMap_HashCode(t *testing.T) {
 	type structA struct {
 		A string

--- a/internal/type_test.go
+++ b/internal/type_test.go
@@ -22,6 +22,9 @@ func TestFromReflected(t *testing.T) {
 	v = tf.FromReflected(reflect.ValueOf(map[int]string{1: `a`}).Type())
 	require.Assignable(t, tf.Map(typ.Integer, typ.String), v)
 
+	v = tf.FromReflected(reflect.ValueOf(map[int]interface{}{1: `a`}).Type())
+	require.Assignable(t, tf.Map(typ.Integer, typ.Any), v)
+
 	v = tf.FromReflected(reflect.ValueOf(&map[int]string{1: `a`}).Type())
 	require.Assignable(t, v, tf.Map(typ.Integer, typ.String))
 	require.Assignable(t, v, typ.Nil)


### PR DESCRIPTION
Prior to this commit, a Copy(true) on a Map or Array would result
in a deep freezing copy but a Copy(false) would just do a shallow
thawing copy. This commit ensures that Copy(false) is performs a
deep thawing copy.