### PR TITLE
Let serializer recognize and propagate references to collector

### DIFF
--- a/streamer/json_test.go
+++ b/streamer/json_test.go
@@ -68,6 +68,15 @@ func TestJSON_ComplexKeys(t *testing.T) {
 		b.String())
 }
 
+func TestUnmarshalJSON_ref(t *testing.T) {
+	v := streamer.UnmarshalJSON(
+		[]byte(`[["a","b"],{"__ref":1}]`),
+		streamer.DgoDialect())
+	x := vf.Strings(`a`, `b`)
+	v2 := vf.Values(x, x)
+	require.Equal(t, v2, v)
+}
+
 func TestUnmarshalJSON_complexKeys(t *testing.T) {
 	v := streamer.UnmarshalJSON(
 		[]byte(`{"__type":"map","__value":[{"__type":"binary","__value":"AQID"},"value of binary","hey","value of hey"]}`),

--- a/streamer/streamer.go
+++ b/streamer/streamer.go
@@ -253,6 +253,13 @@ func (sc *context) emitBinary(value dgo.Binary) {
 
 func (sc *context) emitMap(value dgo.Map) {
 	if sc.consumer.CanDoComplexKeys() || value.StringKeys() {
+		if value.Len() == 1 {
+			if ref, ok := value.Get(sc.config.Dialect.RefKey()).(dgo.Integer); ok {
+				// Propagate refs verbatim
+				sc.consumer.AddRef(int(ref.GoInt()))
+				return
+			}
+		}
 		sc.process(value, func() {
 			sc.addMap(value.Len(), func() {
 				value.EachEntry(func(e dgo.MapEntry) {


### PR DESCRIPTION
The serializer would propagate a map in the form {"__ref":4} to the
collector as any other map. This was wrong. The serializer must call
the collectors `AddRef` method instead of its `AddMap` when such a map
is encountered. Not doing so means loss of ref semantics. This commit
ensures that `AddRef` is called correctly.

Closes lyraproj/hiera#74