### PR TITLE
Add JSON decoded that retains order of object entries in Map

### DIFF
--- a/internal/sensitive_test.go
+++ b/internal/sensitive_test.go
@@ -94,7 +94,11 @@ func TestSensitive(t *testing.T) {
 
 	c = s.ThawedCopy().(dgo.Sensitive)
 	require.NotSame(t, s, c)
-	require.False(t, c.Frozen()) // string is frozen regardless
+	require.False(t, c.Frozen()) // c no longer frozen
+
+	s = vf.Sensitive(vf.String(`a`))
+	c = s.ThawedCopy().(dgo.Sensitive)
+	require.Same(t, s, c)
 
 	require.Equal(t, `sensitive [value redacted]`, s.String())
 

--- a/internal/value_test.go
+++ b/internal/value_test.go
@@ -89,6 +89,8 @@ func TestValue(t *testing.T) {
 	v = vf.Value(struct{ A int }{10})
 	require.Equal(t, struct{ A int }{10}, v)
 
+	require.Equal(t, 42, vf.Value(json.Number(`42`)))
+	require.Equal(t, 3.14, vf.Value(json.Number(`3.14`)))
 	require.Panic(t, func() { vf.Value(json.Number(`not a float`)) }, `invalid`)
 }
 

--- a/streamer/json.go
+++ b/streamer/json.go
@@ -29,27 +29,110 @@ func MarshalJSON(v interface{}, dialect Dialect) []byte {
 	return b.Bytes()
 }
 
-// UnmarshalJSON decodes the JSON representation of the given bytes into a dgo.Value
+// UnmarshalJSON decodes the JSON representation of the given bytes into a dgo.Value. The order of entries
+// in an object is retained in its corresponding dgo.Map and rich data constructs such as Sensitive and Timestamp are
+// converted.
 func UnmarshalJSON(b []byte, dialect Dialect) dgo.Value {
-	var iv interface{}
-
 	// Using an explicit decoder enables setting the UseNumber() attribute which in turn
 	// will allow the vf.Value() method to perform the actual decoding of that number and
 	// turn it into an int64 or a float64 depending on the if the string representation can
 	// be parsed into an integer or not.
 	je := json.NewDecoder(bytes.NewReader(b))
 	je.UseNumber()
-	err := je.Decode(&iv)
-	if err != nil {
-		panic(err)
-	}
+
 	opts := DefaultOptions()
 	if dialect != nil {
 		opts.Dialect = dialect
 	}
 	vc := DataDecoder(nil, opts.Dialect)
-	New(nil, opts).Stream(vf.Value(iv), vc)
+
+	j := &jsonDecoder{consumer: vc, refKey: opts.Dialect.RefKey().GoString(), decoder: je}
+	j.decode()
 	return vc.Value()
+}
+
+// jsonDecoder decodes a json stream into a dgo.Value. It retains the order of maps and
+// resolves references.
+type jsonDecoder struct {
+	consumer Consumer
+	refKey   string
+	decoder  *json.Decoder
+	pbToken  json.Token
+}
+
+func (j *jsonDecoder) decode() {
+	j.decodeElem(json.Delim(0))
+}
+
+func (j *jsonDecoder) decodeElem(end json.Delim) bool {
+	switch t := j.nextToken().(type) {
+	case json.Delim:
+		if t == end {
+			return false
+		}
+		j.decodeCollection(t)
+	case string:
+		j.consumer.Add(vf.String(t))
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			j.consumer.Add(vf.Integer(i))
+		} else {
+			f, _ := t.Float64()
+			j.consumer.Add(vf.Float(f))
+		}
+	case bool:
+		j.consumer.Add(vf.Boolean(t))
+	default:
+		j.consumer.Add(vf.Nil)
+	}
+	return true
+}
+
+func (j *jsonDecoder) decodeCollection(delim json.Delim) {
+	if delim == json.Delim('{') {
+		k := j.nextToken()
+		if k != j.refKey {
+			j.pbToken = k
+			j.consumer.AddMap(0, j.decodeMap)
+		} else {
+			if n, ok := j.nextToken().(json.Number); ok {
+				if ri, err := n.Int64(); err == nil {
+					j.consumer.AddRef(int(ri))
+					return
+				}
+			}
+			panic(fmt.Errorf(`expected integer after key "%s"`, j.refKey))
+		}
+	} else {
+		j.consumer.AddArray(0, j.decodeArray)
+	}
+}
+
+func (j *jsonDecoder) decodeArray() {
+	for j.decodeElem(json.Delim(']')) {
+	}
+}
+
+func (j *jsonDecoder) decodeMap() {
+	for j.decodeElem(json.Delim('}')) {
+	}
+}
+
+func (j *jsonDecoder) nextToken() (t json.Token) {
+	if j.pbToken != nil {
+		t = j.pbToken
+		j.pbToken = nil
+	} else {
+		var err error
+		t, err = j.decoder.Token()
+		if err != nil {
+			if io.EOF == err {
+				err = io.ErrUnexpectedEOF
+			}
+			panic(err)
+		}
+	}
+	return
 }
 
 // JSON creates a new Consumer encode everything into JSON
@@ -63,7 +146,7 @@ type jsonEncoder struct {
 	state   int
 }
 
-func (j *jsonEncoder) AddArray(len int, doer dgo.Doer) {
+func (j *jsonEncoder) AddArray(_ int, doer dgo.Doer) {
 	j.delimit(func() {
 		j.state = firstInArray
 		assertOk(j.out.Write([]byte{'['}))
@@ -72,7 +155,7 @@ func (j *jsonEncoder) AddArray(len int, doer dgo.Doer) {
 	})
 }
 
-func (j *jsonEncoder) AddMap(len int, doer dgo.Doer) {
+func (j *jsonEncoder) AddMap(_ int, doer dgo.Doer) {
 	j.delimit(func() {
 		assertOk(j.out.Write([]byte{'{'}))
 		j.state = firstInObject

--- a/streamer/json_test.go
+++ b/streamer/json_test.go
@@ -70,11 +70,21 @@ func TestJSON_ComplexKeys(t *testing.T) {
 
 func TestUnmarshalJSON_ref(t *testing.T) {
 	v := streamer.UnmarshalJSON(
-		[]byte(`[["a","b"],{"__ref":1}]`),
+		[]byte(`{"x": {"z": ["a","b"]}, "y": {"__ref":6}}`),
 		streamer.DgoDialect())
-	x := vf.Strings(`a`, `b`)
-	v2 := vf.Values(x, x)
-	require.Equal(t, v2, v)
+	require.Equal(t, vf.Map(`x`, vf.Map(`z`, vf.Values("a", `b`)), `y`, `b`), v)
+}
+
+func TestUnmarshalJSON_refBad(t *testing.T) {
+	require.Panic(t, func() {
+		streamer.UnmarshalJSON([]byte(`{"x": {"z": ["a","b"]}, "y": {"__ref":"6"}}`), streamer.DgoDialect())
+	}, `expected integer after key "__ref"`)
+}
+
+func TestUnmarshalJSON_badDelim(t *testing.T) {
+	require.Panic(t, func() {
+		streamer.UnmarshalJSON([]byte(``), streamer.DgoDialect())
+	}, `unexpected EOF`)
 }
 
 func TestUnmarshalJSON_complexKeys(t *testing.T) {

--- a/streamer/streamer.go
+++ b/streamer/streamer.go
@@ -3,6 +3,7 @@ package streamer
 
 import (
 	"fmt"
+	"log"
 
 	"github.com/lyraproj/dgo/dgo"
 	"github.com/lyraproj/dgo/vf"
@@ -75,6 +76,7 @@ func (t *rdSerializer) Stream(value dgo.Value, consumer Consumer) {
 	if c.dedupLevel >= MaxDedup && !consumer.CanDoComplexKeys() {
 		c.dedupLevel = NoKeyDedup
 	}
+	log.Println(value.String())
 	c.emitData(value)
 }
 

--- a/streamer/streamer_test.go
+++ b/streamer/streamer_test.go
@@ -141,6 +141,13 @@ func TestEncode_dedup_string_keys(t *testing.T) {
 	require.Same(t, aes[0].Key(), bes[0].Key())
 }
 
+func TestEncode_existingRef(t *testing.T) {
+	v := vf.Map(`x`, vf.Map(`z`, vf.Values(`a`, `b`)), `y`, vf.Map(streamer.DgoDialect().RefKey(), 6))
+	vc := streamer.DataCollector()
+	streamer.New(nil, nil).Stream(v, vc)
+	require.Equal(t, vf.Map(`x`, vf.Map(`z`, vf.Values("a", `b`)), `y`, `b`), vc.Value())
+}
+
 type testNamed struct {
 	A string
 	B int64


### PR DESCRIPTION
In order for `{ __ref: <n> }` constructs to work properly, the sequence
of values in a JSON stream must be retained throughout. The standard
Go JSON decoder uses a `map[string]interface{}` internally and will
therefore map entries in random order. This commit adds a decoder that
creates a dgo.Map directly from the stream and thus, retains the order
in which the entries are added.